### PR TITLE
Add missing query parameters in recordings 

### DIFF
--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -234,11 +234,11 @@ impl HttpMockRequest {
         self.headers.as_ref()
     }
 
-    pub fn query_params(&self) -> HashMap<String, String> {
-        self.query_params_vec().into_iter().collect()
+    pub fn query_params_map(&self) -> HashMap<String, String> {
+        self.query_params().into_iter().collect()
     }
 
-    pub fn query_params_vec(&self) -> Vec<(String, String)> {
+    pub fn query_params(&self) -> Vec<(String, String)> {
         // There doesn't seem to be a way to just parse Query string with `url` crate, so we're
         // prefixing a dummy URL for parsing.
         let url = format!("http://dummy?{}", self.uri().query().unwrap_or(""));
@@ -247,6 +247,15 @@ impl HttpMockRequest {
         url.query_pairs()
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect()
+    }
+
+    pub fn query_param_length(&self) -> usize {
+        // There doesn't seem to be a way to just parse Query string with `url` crate, so we're
+        // prefixing a dummy URL for parsing.
+        let url = format!("http://dummy?{}", self.uri().query().unwrap_or(""));
+        let url = Url::parse(&url).unwrap();
+
+        url.query_pairs().count()
     }
 
     pub fn body(&self) -> &HttpMockBytes {

--- a/src/server/matchers/readers.rs
+++ b/src/server/matchers/readers.rs
@@ -645,7 +645,7 @@ pub mod request_value {
     #[inline]
     pub fn query_params(req: &HttpMockRequest) -> Option<Vec<(String, Option<String>)>> {
         Some(
-            req.query_params_vec()
+            req.query_params()
                 .iter()
                 .map(|(k, v)| (k.into(), Some(v.into())))
                 .collect(),

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -638,7 +638,11 @@ fn build_mock_definition(
         query_param_suffix_not: None,
         query_param_matches: None,
         query_param_count: None,
-        query_param: None,
+        query_param: if request.query_param_length() == 0 {
+            None
+        } else {
+            Some(request.query_params())
+        },
         form_urlencoded_tuple_exists: None,
         form_urlencoded_tuple_missing: None,
         form_urlencoded_tuple_includes: None,


### PR DESCRIPTION
Fixes https://github.com/httpmock/httpmock/issues/174