### PR TITLE
upgrade Rust to 1.83

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["http", "mock", "test"]
 categories = ["development-tools::testing"]
 license = "MIT"
 repository = "https://github.com/httpmock/httpmock"
-rust-version = "1.82.0"
+rust-version = "1.83.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Upgrade to Rust 1.83 is required, as without it the build fails with:
```
error: rustc 1.82.0 is not supported by the following packages:
  icu_collections@2.1.1 requires rustc 1.83
  icu_locale_core@2.1.1 requires rustc 1.83
  icu_normalizer@2.1.1 requires rustc 1.83
  icu_normalizer_data@2.1.1 requires rustc 1.83
  icu_normalizer_data@2.1.1 requires rustc 1.83
  icu_normalizer_data@2.1.1 requires rustc 1.83
  icu_properties@2.1.1 requires rustc 1.83
  icu_properties_data@2.1.1 requires rustc 1.83
  icu_properties_data@2.1.1 requires rustc 1.83
  icu_properties_data@2.1.1 requires rustc 1.83
  icu_provider@2.1.1 requires rustc 1.83
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.82.0
```

e.g. latest commit on master: https://github.com/httpmock/httpmock/actions/runs/18953463710/job/54124026986