### PR TITLE
Fix is_false custom matcher

### DIFF
--- a/src/server/matchers/mod.rs
+++ b/src/server/matchers/mod.rs
@@ -877,7 +877,7 @@ pub fn all() -> Vec<Box<dyn Matcher + Sync + Send>> {
             entity_name: "custom matcher function",
             matcher_function: "is_false",
             comparator: Box::new(FunctionMatchesRequestComparator::new(false)),
-            expectation: readers::expectations::is_true,
+            expectation: readers::expectations::is_false,
             request_value: readers::request_value::full_request,
             weight: 1,
         }),

--- a/src/server/matchers/readers.rs
+++ b/src/server/matchers/readers.rs
@@ -508,6 +508,13 @@ pub mod expectations {
         mock.is_true.as_ref().map(|b| b.iter().map(|f| f).collect())
     }
 
+    #[inline]
+    pub fn is_false(
+        mock: &RequestRequirements,
+    ) -> Option<Vec<&Arc<dyn Fn(&HttpMockRequest) -> bool + 'static + Sync + Send>>> {
+        mock.is_false.as_ref().map(|b| b.iter().map(|f| f).collect())
+    }
+
     pub fn form_urlencoded_tuple(
         mock: &RequestRequirements,
     ) -> Option<Vec<(&String, Option<&String>)>> {


### PR DESCRIPTION
Call `is_true` matcher once per request and don't call `is_false` at all.

The docs for `is_false` state:
> If this function returns false, the request is considered a match

But I had to return true for the test to work. So this is likely another bug.