### PR TITLE
fix: remove unneeded 'Deserialize' trait bound

### DIFF
--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -5191,7 +5191,10 @@ impl Then {
     /// assert_eq!(status, 200);
     /// assert_eq!(user.name, "Hans");
     /// ```
-    pub fn json_body_obj<T: Serialize + ?Sized>(self, body: &T) -> Self {
+    pub fn json_body_obj<T>(self, body: &T) -> Self
+    where
+        T: Serialize + ?Sized,
+    {
         let json_body =
             serde_json::to_value(body).expect("Failed to serialize object to JSON string");
         self.json_body(json_body)


### PR DESCRIPTION
the 'Deserialize' bound appears to simply be a mistake.

the implicit `Sized` bounds can be relaxed since the method accepts a reference, which is always sized.

this allows passing `&str` to the methods