### PR TITLE
Add response header filtering for recordings

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -355,6 +355,25 @@ impl RecordingRuleBuilder {
         self
     }
 
+    pub fn record_response_header<IntoString: Into<String>>(mut self, header: IntoString) -> Self {
+        let mut config = self.config.take();
+        config.record_response_headers.push(header.into());
+        self.config.set(config);
+        self
+    }
+
+    pub fn record_response_headers<IntoString: Into<String>>(
+        mut self,
+        headers: Vec<IntoString>,
+    ) -> Self {
+        let mut config = self.config.take();
+        config
+            .record_response_headers
+            .extend(headers.into_iter().map(Into::into));
+        self.config.set(config);
+        self
+    }
+
     pub fn filter<WhenSpecFn>(mut self, when: WhenSpecFn) -> Self
     where
         WhenSpecFn: FnOnce(When),

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -998,6 +998,7 @@ impl MockServer {
             request_requirements: RequestRequirements::new(),
             record_headers: Vec::new(),
             record_response_delays: false,
+            record_response_headers: Vec::new(),
         }));
 
         rule(RecordingRuleBuilder {

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -1218,6 +1218,9 @@ pub struct RecordingRuleConfig {
     pub request_requirements: RequestRequirements,
     pub record_headers: Vec<String>,
     pub record_response_delays: bool,
+    // NOTE! If empty (default), all headers are kept for backwards compatibility.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub record_response_headers: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -20,7 +20,7 @@ use crate::server::persistence::{deserialize_mock_defs_from_yaml, serialize_mock
 use crate::common::data::{ForwardingRuleConfig, ProxyRuleConfig, RecordingRuleConfig};
 use bytes::Bytes;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     convert::{TryFrom, TryInto},
     sync::{Arc, Mutex},
     time::Duration,
@@ -669,6 +669,18 @@ fn build_mock_definition(
 
     if config.record_response_delays {
         response.delay = Some(time_taken.as_millis() as u64)
+    }
+
+    if !config.record_response_headers.is_empty() {
+        if let Some(headers) = &mut response.headers {
+            let headers_to_keep: HashSet<_> = config
+                .record_response_headers
+                .iter()
+                .map(|name| name.to_lowercase())
+                .collect();
+
+            headers.retain(|(name, _)| headers_to_keep.contains(&name.to_lowercase()));
+        }
     }
 
     Ok(MockDefinition { request, response })


### PR DESCRIPTION
I was suprised by `record_request_header` aswell, but found [a previous issue](https://github.com/httpmock/httpmock/issues/128) and realized it was my "quick" reading of the function name the problem. I ended up looking up how the filtering is done, and realized it would be a quick addition to add it for responses, without causing a backwards incompatible change.