### PR TITLE
style: remove unused imports

### DIFF
--- a/src/api/adapter/local.rs
+++ b/src/api/adapter/local.rs
@@ -1,21 +1,20 @@
+use std::{net::SocketAddr, sync::Arc};
+
 use async_trait::async_trait;
+#[cfg(feature = "record")]
 use bytes::Bytes;
-use std::{borrow::Borrow, fmt::Debug, net::SocketAddr, sync::Arc};
-
-use futures_util::TryFutureExt;
-
-use crate::api::adapter::{MockServerAdapter, ServerAdapterError};
 
 use crate::{
-    api::adapter::ServerAdapterError::{MockNotFound, UpstreamError},
+    api::adapter::{
+        MockServerAdapter, ServerAdapterError,
+        ServerAdapterError::{MockNotFound, UpstreamError},
+    },
+    common::data::{
+        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
+        ForwardingRuleConfig, MockDefinition, ProxyRuleConfig, RecordingRuleConfig,
+        RequestRequirements,
+    },
     server::state::{HttpMockStateManager, StateManager},
-};
-
-use crate::common::data::{ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording};
-
-use crate::common::data::{
-    ClosestMatch, ForwardingRuleConfig, MockDefinition, ProxyRuleConfig, RecordingRuleConfig,
-    RequestRequirements,
 };
 
 pub struct LocalMockServerAdapter {

--- a/src/api/adapter/mod.rs
+++ b/src/api/adapter/mod.rs
@@ -1,19 +1,19 @@
-use std::{net::SocketAddr, str::FromStr};
+use std::net::SocketAddr;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
-use serde::{Deserialize, Serialize};
-
-use crate::common::data::{ActiveForwardingRule, ActiveMock, ActiveProxyRule};
-
-use crate::common::data::{ActiveRecording, ClosestMatch, MockDefinition, RequestRequirements};
+use crate::common::data::{
+    ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
+    MockDefinition, RequestRequirements,
+};
 
 pub mod local;
 
-use crate::common::data::{ForwardingRuleConfig, ProxyRuleConfig, RecordingRuleConfig};
-
+#[cfg(feature = "record")]
+use bytes::Bytes;
 use thiserror::Error;
+
+use crate::common::data::{ForwardingRuleConfig, ProxyRuleConfig, RecordingRuleConfig};
 
 #[derive(Error, Debug)]
 pub enum ServerAdapterError {

--- a/src/api/adapter/remote.rs
+++ b/src/api/adapter/remote.rs
@@ -1,28 +1,28 @@
-use crate::common::data::{
-    ForwardingRuleConfig, MockServerHttpResponse, ProxyRuleConfig, RecordingRuleConfig,
-};
 use std::{borrow::Borrow, net::SocketAddr, sync::Arc};
 
-use crate::api::{
-    adapter::{
-        ServerAdapterError,
-        ServerAdapterError::{
-            InvalidMockDefinitionError, JsonDeserializationError, JsonSerializationError,
-            UpstreamError,
-        },
-    },
-    MockServerAdapter,
-};
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Request, StatusCode};
 
-use crate::common::{
-    data::{
-        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
-        MockDefinition, RequestRequirements,
+use crate::{
+    api::{
+        adapter::{
+            ServerAdapterError,
+            ServerAdapterError::{
+                InvalidMockDefinitionError, JsonDeserializationError, JsonSerializationError,
+                UpstreamError,
+            },
+        },
+        MockServerAdapter,
     },
-    http::HttpClient,
+    common::{
+        data::{
+            ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
+            ForwardingRuleConfig, MockDefinition, MockServerHttpResponse, ProxyRuleConfig,
+            RecordingRuleConfig, RequestRequirements,
+        },
+        http::HttpClient,
+    },
 };
 
 pub struct RemoteMockServerAdapter {

--- a/src/api/mock.rs
+++ b/src/api/mock.rs
@@ -1,14 +1,12 @@
-use std::{io::Write, net::SocketAddr};
-use tabwriter::TabWriter;
+use std::net::SocketAddr;
 
-use crate::api::output;
 #[cfg(feature = "color")]
 use colored::*;
-use serde::{Deserialize, Serialize};
 
-use crate::api::server::MockServer;
-
-use crate::common::util::Join;
+use crate::{
+    api::{output, server::MockServer},
+    common::util::Join,
+};
 
 /// Provides a reference to a mock configuration stored on a [MockServer](struct.MockServer.html).
 /// This structure is used for interacting with, monitoring, and managing a specific mock's lifecycle,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,24 +1,18 @@
 // TODO: Remove this at some point
 #![allow(clippy::needless_lifetimes)]
 
-pub use adapter::{local::LocalMockServerAdapter, MockServerAdapter};
-
-use serde::{Deserialize, Serialize};
-use std::str::FromStr;
-
 #[cfg(feature = "remote")]
 pub use adapter::remote::RemoteMockServerAdapter;
-
-#[cfg(feature = "record")]
-pub use proxy::{Recording, RecordingRuleBuilder};
-
+pub use adapter::{local::LocalMockServerAdapter, MockServerAdapter};
+pub use mock::{Mock, MockExt};
 #[cfg(feature = "proxy")]
 pub use proxy::{ForwardingRule, ForwardingRuleBuilder, ProxyRule, ProxyRuleBuilder};
-
-use crate::common;
-pub use mock::{Mock, MockExt};
+#[cfg(feature = "record")]
+pub use proxy::{Recording, RecordingRuleBuilder};
 pub use server::MockServer;
 pub use spec::{Then, When};
+
+use crate::common;
 
 mod adapter;
 mod mock;

--- a/src/api/output.rs
+++ b/src/api/output.rs
@@ -1,18 +1,19 @@
 use std::io::Write;
 
-use crate::common::{
-    data::{
-        ClosestMatch, Diff, DiffResult, FunctionComparison, KeyValueComparison,
-        KeyValueComparisonKeyValuePair, Mismatch, SingleValueComparison,
-    },
-    util::title_case,
-};
-
-use tabwriter::TabWriter;
-
-use crate::server::matchers::generic::MatchingStrategy;
 #[cfg(feature = "color")]
 use colored::Colorize;
+use tabwriter::TabWriter;
+
+use crate::{
+    common::{
+        data::{
+            ClosestMatch, Diff, DiffResult, FunctionComparison, KeyValueComparison,
+            KeyValueComparisonKeyValuePair, Mismatch, SingleValueComparison,
+        },
+        util::title_case,
+    },
+    server::matchers::generic::MatchingStrategy,
+};
 
 const QUOTED_TEXT: &str = "quoted for better readability";
 

--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1,17 +1,19 @@
+#[cfg(feature = "record")]
+use std::path::{Path, PathBuf};
+use std::{cell::Cell, rc::Rc};
+
+#[cfg(feature = "record")]
+use bytes::Bytes;
+
+#[cfg(feature = "record")]
+use crate::common::util::write_file;
 use crate::{
     api::server::MockServer,
     common::{
-        data::RecordingRuleConfig,
-        data::RequestRequirements,
-        util::{write_file, Join},
+        data::{RecordingRuleConfig, RequestRequirements},
+        util::Join,
     },
     When,
-};
-use bytes::Bytes;
-use std::{
-    cell::Cell,
-    path::{Path, PathBuf},
-    rc::Rc,
 };
 
 /// Represents a forwarding rule on a [MockServer](struct.MockServer.html), allowing HTTP requests

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -1,18 +1,18 @@
-use crate::prelude::HttpMockResponse;
+use std::{
+    cell::Cell, convert::TryInto, path::Path, rc::Rc, str::FromStr, sync::Arc, time::Duration,
+};
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
 use crate::{
     common::{
         data::{MockServerHttpResponse, RequestRequirements},
         util::{get_test_resource_file_path, update_cell, HttpMockBytes},
     },
-    prelude::HttpMockRequest,
+    prelude::{HttpMockRequest, HttpMockResponse},
     Method, Regex,
-};
-use bytes::Bytes;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::{
-    cell::Cell, convert::TryInto, fs::read_to_string, path::Path, rc::Rc, str::FromStr, sync::Arc,
-    time::Duration,
 };
 
 /// Represents the conditions that an incoming HTTP request must satisfy to be handled by the mock server.

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -1,18 +1,5 @@
 extern crate serde_regex;
 
-use crate::{
-    common::{
-        data::Error::{
-            HeaderDeserializationError, RequestConversionError, StaticMockConversionError,
-        },
-        util::HttpMockBytes,
-    },
-    server::matchers::generic::MatchingStrategy,
-};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use bytes::Bytes;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::{
     cmp::Ordering,
     collections::HashMap,
@@ -22,11 +9,24 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
-use url::Url;
 
-use crate::server::RequestMetadata;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use bytes::Bytes;
 #[cfg(feature = "cookies")]
 use headers::{Cookie, HeaderMapExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use url::Url;
+
+use crate::{
+    common::{
+        data::Error::{
+            HeaderDeserializationError, RequestConversionError, StaticMockConversionError,
+        },
+        util::HttpMockBytes,
+    },
+    server::{matchers::generic::MatchingStrategy, RequestMetadata},
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -733,10 +733,11 @@ impl TryFrom<&http::Response<Bytes>> for MockServerHttpResponse {
 
 /// Serializes and deserializes the response body to/from a Base64 string.
 mod opt_vector_serde_base64 {
-    use crate::common::util::HttpMockBytes;
     use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use bytes::Bytes;
     use serde::{Deserialize, Deserializer, Serializer};
+
+    use crate::common::util::HttpMockBytes;
 
     // See the following references:
     // https://github.com/serde-rs/serde/blob/master/serde/src/ser/impls.rs#L99

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,3 +1,5 @@
+use std::{convert::TryInto, sync::Arc};
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Request, Response};
@@ -8,7 +10,6 @@ use hyper_util::{
     client::legacy::{connect::HttpConnector, Client},
     rt::TokioExecutor,
 };
-use std::{convert::TryInto, sync::Arc};
 use thiserror::Error;
 use tokio::runtime::Runtime;
 

--- a/src/common/runtime.rs
+++ b/src/common/runtime.rs
@@ -1,4 +1,5 @@
 use std::{future::Future, time::Duration};
+
 use tokio::{runtime::Runtime, task::LocalSet};
 
 pub(crate) async fn sleep(duration: Duration) {

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    cell::Cell,
     env,
     fs::{create_dir_all, File},
     future::Future,
@@ -7,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
@@ -15,8 +17,7 @@ use bytes::Bytes;
 use crossbeam_utils::sync::{Parker, Unparker};
 use futures_timer::Delay;
 use futures_util::{pin_mut, task::ArcWake};
-use serde::{Deserialize, Serialize, Serializer};
-use std::{cell::Cell, time::Duration};
+use serde::{Deserialize, Serialize};
 
 // ===============================================================================================
 // Misc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,28 +95,17 @@
 //! This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
 //! warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the MIT Public License for more details.
 
-use std::{borrow::BorrowMut, net::ToSocketAddrs};
-
-use std::str::FromStr;
-
-use serde::{Deserialize, Serialize};
-
-use api::MockServerAdapter;
-
 mod common;
-use common::util::Join;
 
 pub use api::{Method, Mock, MockExt, MockServer, Regex, Then, When};
 pub use common::data::{HttpMockRequest, HttpMockResponse};
-
 mod api;
 pub mod server;
 
-#[cfg(feature = "record")]
-pub use api::{Recording, RecordingRuleBuilder};
-
 #[cfg(feature = "proxy")]
 pub use api::{ForwardingRule, ForwardingRuleBuilder, ProxyRule, ProxyRuleBuilder};
+#[cfg(feature = "record")]
+pub use api::{Recording, RecordingRuleBuilder};
 
 pub mod prelude {
     #[doc(no_inline)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::{env, path::PathBuf};
 
 use clap::Parser;
-
 use httpmock::server::HttpMockServerBuilder;
 use tracing_subscriber::EnvFilter;
 

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -1,19 +1,22 @@
+#[cfg(feature = "record")]
+use std::path::PathBuf;
+use std::{error::Error, sync::Arc};
+
 #[cfg(feature = "proxy")]
 use crate::common::http::{HttpClient, HttpMockHttpClient};
-#[cfg(any(feature = "record", feature = "record"))]
+#[cfg(feature = "record")]
 use crate::server::persistence::read_static_mock_definitions;
-#[cfg(feature = "https")]
-use crate::server::server::MockServerHttpsConfig;
-#[cfg(feature = "https")]
-use crate::server::tls::{CertificateResolverFactory, GeneratingCertificateResolverFactory};
-
 use crate::server::{
     handler::HttpMockHandler,
     server::{MockServer, MockServerConfig},
     state::{HttpMockStateManager, StateManager},
     HttpMockServer,
 };
-use std::{error::Error, path::PathBuf, sync::Arc};
+#[cfg(feature = "https")]
+use crate::server::{
+    server::MockServerHttpsConfig,
+    tls::{CertificateResolverFactory, GeneratingCertificateResolverFactory},
+};
 
 const DEFAULT_CA_PRIVATE_KEY: &str = include_str!("../../certs/ca.key");
 const DEFAULT_CA_CERTIFICATE: &str = include_str!("../../certs/ca.pem");

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -1,44 +1,44 @@
-use crate::common::data::{
-    ActiveForwardingRule, ActiveProxyRule, Error as DataError, ErrorResponse, MockDefinition,
-    RequestRequirements,
+use std::{
+    convert::TryInto,
+    fmt::{Debug, Display},
+    str::FromStr,
+    sync::Arc,
 };
 
+use async_trait::async_trait;
+use http::{HeaderValue, StatusCode, Uri};
+use hyper::{body::Bytes, Method, Request, Response};
+use path_tree::{Path, PathTree};
+use serde::{de::DeserializeOwned, Serialize};
+use thiserror::Error;
+use tokio::time::Instant;
+
+#[cfg(feature = "record")]
+use crate::common::data::RecordingRuleConfig;
+#[cfg(feature = "proxy")]
+use crate::common::data::{ActiveForwardingRule, ActiveProxyRule};
+#[cfg(any(feature = "remote", feature = "proxy"))]
+use crate::common::http::{Error as HttpClientError, HttpClient};
 use crate::{
-    common::runtime,
+    common::{
+        data,
+        data::{
+            Error as DataError, ErrorResponse, ForwardingRuleConfig, MockDefinition,
+            ProxyRuleConfig, RequestRequirements,
+        },
+        runtime,
+    },
+    prelude::{HttpMockRequest, HttpMockResponse},
     server::{
         handler::Error::{
             InvalidHeader, ParamError, ParamFormatError, RequestBodyDeserializeError,
             RequestConversionError, ResponseBodyConversionError, ResponseBodySerializeError,
+            ResponseDataConversionError,
         },
         state,
         state::StateManager,
     },
 };
-use std::convert::TryInto;
-
-#[cfg(any(feature = "remote", feature = "proxy"))]
-use crate::common::http::{Error as HttpClientError, HttpClient};
-
-use crate::common::data::{ForwardingRuleConfig, ProxyRuleConfig, RecordingRuleConfig};
-
-use crate::common::data;
-use crate::prelude::{HttpMockRequest, HttpMockResponse};
-use crate::server::handler::Error::ResponseDataConversionError;
-use async_trait::async_trait;
-use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
-use http_body_util::BodyExt;
-use hyper::{body::Bytes, Method, Request, Response};
-use path_tree::{Path, PathTree};
-use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    fmt::{Debug, Display},
-    str::FromStr,
-    sync::Arc,
-    thread,
-    time::Duration,
-};
-use thiserror::Error;
-use tokio::time::Instant;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -436,7 +436,7 @@ where
 
         if !rule.config.request_header.is_empty() {
             for (key, value) in &rule.config.request_header {
-                let key = HeaderName::from_str(key).map_err(|err| {
+                let key = http::HeaderName::from_str(key).map_err(|err| {
                     InvalidHeader(format!("invalid header key: {}", err.to_string()))
                 })?;
 
@@ -467,7 +467,7 @@ where
             let headers = req.headers_mut();
 
             for (key, value) in &rule.config.request_header {
-                let key = HeaderName::from_str(key).map_err(|err| {
+                let key = http::HeaderName::from_str(key).map_err(|err| {
                     InvalidHeader(format!("invalid header key: {}", err.to_string()))
                 })?;
 

--- a/src/server/matchers/comparators.rs
+++ b/src/server/matchers/comparators.rs
@@ -1,21 +1,23 @@
+use std::{borrow::Cow, sync::Arc};
+
 use assert_json_diff::{assert_json_matches_no_panic, CompareMode, Config};
 use bytes::Bytes;
 use serde_json::Value;
-use std::{borrow::Cow, convert::TryInto, ops::Deref, sync::Arc};
 
 use crate::{
     common::{
         data::{HttpMockRegex, HttpMockRequest},
         util::HttpMockBytes,
     },
-    server::matchers::comparison::{
-        distance_for, distance_for_prefix, distance_for_substring, distance_for_suffix,
-        equal_weight_distance_for, hostname_equals, regex_unmatched_length, string_contains,
-        string_distance, string_equals, string_has_prefix, string_has_suffix,
+    server::matchers::{
+        comparison,
+        comparison::{
+            distance_for, distance_for_prefix, distance_for_substring, distance_for_suffix,
+            equal_weight_distance_for, hostname_equals, regex_unmatched_length, string_contains,
+            string_distance, string_equals, string_has_prefix, string_has_suffix,
+        },
     },
 };
-
-use crate::server::matchers::comparison;
 
 pub trait ValueComparator<S: ?Sized, T: ?Sized> {
     fn matches(&self, mock_value: &Option<&S>, req_value: &Option<&T>) -> bool;
@@ -811,6 +813,9 @@ impl ValueComparator<Arc<dyn Fn(&HttpMockRequest) -> bool + 'static + Sync + Sen
 
 #[cfg(test)]
 mod test {
+    use regex::Regex;
+    use serde_json::json;
+
     use crate::{
         common::data::HttpMockRegex,
         server::matchers::comparators::{
@@ -819,8 +824,6 @@ mod test {
             ValueComparator,
         },
     };
-    use regex::Regex;
-    use serde_json::json;
 
     fn run_test<S, T>(
         comparator: &dyn ValueComparator<S, T>,

--- a/src/server/matchers/comparison.rs
+++ b/src/server/matchers/comparison.rs
@@ -1,7 +1,9 @@
-use crate::common::{data::HttpMockRegex, util::HttpMockBytes};
-use regex::Regex;
 use std::{convert::TryInto, ops::Deref};
+
+use regex::Regex;
 use stringmetrics::LevWeights;
+
+use crate::common::{data::HttpMockRegex, util::HttpMockBytes};
 
 pub fn string_has_prefix(
     case_sensitive: bool,
@@ -1724,8 +1726,9 @@ pub fn regex_string_distance(
 
 #[cfg(test)]
 mod regex_string_distance_tests {
-    use super::*;
     use regex::Regex;
+
+    use super::*;
 
     #[test]
     fn test_non_negated_full_match() {

--- a/src/server/matchers/generic.rs
+++ b/src/server/matchers/generic.rs
@@ -1,6 +1,7 @@
+use std::{collections::HashSet, fmt::Display};
+
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
-use std::{collections::HashSet, fmt::Display};
 
 use crate::{
     common::{

--- a/src/server/matchers/mod.rs
+++ b/src/server/matchers/mod.rs
@@ -1,21 +1,19 @@
-use std::{convert::TryInto, fmt::Display, ops::Deref};
-
-use serde::{Deserialize, Serialize};
-
-use crate::common::data::{HttpMockRequest, Mismatch, RequestRequirements, Tokenizer};
-
-use crate::server::matchers::comparators::{
-    AnyValueComparator, BytesExactMatchComparator, BytesIncludesComparator, BytesPrefixComparator,
-    BytesSuffixComparator, FunctionMatchesRequestComparator, HostEqualsComparator,
-    HttpMockBytesPatternComparator, JSONContainsMatchComparator, JSONExactMatchComparator,
-    StringContainsComparator, StringEqualsComparator, StringPatternMatchComparator,
-    StringPrefixMatchComparator, StringRegexMatchComparator, StringSuffixMatchComparator,
-    U16ExactMatchComparator,
-};
-
-use crate::server::matchers::generic::{
-    FunctionValueMatcher, KeyValueOperator, MatchingStrategy, MultiValueCountMatcher,
-    MultiValueMatcher, SingleValueMatcher,
+use crate::{
+    common::data::{HttpMockRequest, Mismatch, RequestRequirements, Tokenizer},
+    server::matchers::{
+        comparators::{
+            AnyValueComparator, BytesExactMatchComparator, BytesIncludesComparator,
+            BytesPrefixComparator, BytesSuffixComparator, FunctionMatchesRequestComparator,
+            HostEqualsComparator, HttpMockBytesPatternComparator, JSONContainsMatchComparator,
+            JSONExactMatchComparator, StringContainsComparator, StringEqualsComparator,
+            StringPatternMatchComparator, StringPrefixMatchComparator, StringRegexMatchComparator,
+            StringSuffixMatchComparator, U16ExactMatchComparator,
+        },
+        generic::{
+            FunctionValueMatcher, KeyValueOperator, MatchingStrategy, MultiValueCountMatcher,
+            MultiValueMatcher, SingleValueMatcher,
+        },
+    },
 };
 
 pub mod comparators;

--- a/src/server/matchers/readers.rs
+++ b/src/server/matchers/readers.rs
@@ -1,4 +1,8 @@
 pub mod expectations {
+    use std::sync::Arc;
+
+    use serde_json::Value;
+
     use crate::{
         common::{
             data::{HttpMockRegex, RequestRequirements},
@@ -6,8 +10,6 @@ pub mod expectations {
         },
         prelude::HttpMockRequest,
     };
-    use serde_json::Value;
-    use std::sync::Arc;
 
     #[inline]
     pub fn scheme_equal_to(mock: &RequestRequirements) -> Option<Vec<&String>> {
@@ -598,7 +600,6 @@ pub mod expectations {
 
 pub mod request_value {
     use crate::{common::util::HttpMockBytes, prelude::HttpMockRequest};
-    use serde_json::Value;
 
     #[inline]
     pub fn scheme(req: &HttpMockRequest) -> Option<String> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,14 +1,4 @@
 #![allow(clippy::trivial_regex)]
-use std::{borrow::Borrow, str::FromStr};
-
-use crate::server::matchers::Matcher;
-use bytes::Bytes;
-use futures_util::task::Spawn;
-use hyper::body::{Body, Buf};
-use std::{future::Future, net::SocketAddr};
-
-use futures_util::{FutureExt, TryStreamExt};
-use http_body_util::BodyExt;
 
 mod builder;
 mod handler;
@@ -22,10 +12,10 @@ mod persistence;
 #[cfg(feature = "https")]
 mod tls;
 
-use crate::server::{handler::HttpMockHandler, server::MockServer, state::HttpMockStateManager};
-
 pub use builder::HttpMockServerBuilder;
 pub use server::Error;
+
+use crate::server::{handler::HttpMockHandler, server::MockServer, state::HttpMockStateManager};
 
 // We want to expose this error to the user
 pub type HttpMockServer = MockServer<HttpMockHandler<HttpMockStateManager>>;

--- a/src/server/persistence.rs
+++ b/src/server/persistence.rs
@@ -1,4 +1,3 @@
-use bytes::{BufMut, Bytes, BytesMut};
 use std::{
     convert::{TryFrom, TryInto},
     fs::{read_dir, read_to_string},
@@ -6,14 +5,16 @@ use std::{
     str::FromStr,
 };
 
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::Deserialize;
-
-use crate::common::data;
 use serde_yaml::{Deserializer, Value as YamlValue};
 use thiserror::Error;
 
 use crate::{
-    common::data::{MockDefinition, StaticMockDefinition},
+    common::{
+        data,
+        data::{MockDefinition, StaticMockDefinition},
+    },
     server::{
         persistence::Error::{DeserializationError, FileReadError},
         state,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,39 +1,38 @@
-use futures_util::{stream::StreamExt, FutureExt};
-use http::{Request, StatusCode};
-use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
-use hyper::body::{Bytes, Incoming};
 use std::{
     future::{pending, Future},
+    io,
     net::SocketAddr,
-    path::PathBuf,
     sync::Arc,
 };
 
-use hyper_util::server::conn::auto::Builder as ServerBuilder;
-
-use crate::server;
-use hyper::{http, service::service_fn, upgrade::on as upgrade_on, Method, Response};
-use hyper_util::rt::tokio::TokioIo;
+use futures_util::FutureExt;
+use http::{Request, StatusCode};
+use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
+use hyper::{
+    body::{Bytes, Incoming},
+    http,
+    service::service_fn,
+    Method, Response,
+};
+use hyper_util::{rt::tokio::TokioIo, server::conn::auto::Builder as ServerBuilder};
+#[cfg(feature = "https")]
+use rustls::ServerConfig;
 use thiserror::Error;
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::oneshot::Sender,
     task::spawn,
 };
+#[cfg(feature = "https")]
+use tokio_rustls::TlsAcceptor;
 
 use crate::server::{
+    self,
     handler::Handler,
     server::Error::{
         BufferError, LocalSocketAddrError, PublishSocketAddrError, RouterError, SocketBindError,
     },
 };
-
-use std::io;
-
-#[cfg(feature = "https")]
-use rustls::ServerConfig;
-#[cfg(feature = "https")]
-use tokio_rustls::TlsAcceptor;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -424,22 +423,14 @@ fn to_service_response(
     Ok(Response::from_parts(parts, full(body)))
 }
 
-use crate::server::Error::{IOError, ServerConnectionError, ServerError, TlsError, Unknown};
-use async_trait::async_trait;
-use bytes::BytesMut;
 use hyper_util::rt::TokioExecutor;
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-};
+#[cfg(feature = "https")]
+use tls_detect::is_encrypted;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "https")]
 use crate::server::tls::{CertificateResolverFactory, TcpStreamPeekBuffer};
-
-use crate::server::RequestMetadata;
-#[cfg(feature = "https")]
-use tls_detect::is_encrypted;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use crate::server::{Error::ServerConnectionError, RequestMetadata};
 
 fn to_absolute_form_uri(req: &mut Request<Bytes>) -> Result<(), Error> {
     let default_scheme = req

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -211,7 +211,7 @@ where
                 // body) to let Hyper proceed with the upgrade.
 
                 let authority = req.uri().authority().map(|a| a.to_string());
-                let on_upgrade = upgrade_on(req);
+                let on_upgrade = hyper::upgrade::on(req);
                 let server = self.clone();
 
                 spawn(async move {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,31 +1,36 @@
+#[cfg(feature = "record")]
+use std::net::ToSocketAddrs;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+#[cfg(feature = "record")]
+use bytes::Bytes;
+use thiserror::Error;
+
+#[cfg(feature = "record")]
 use crate::{
-    common::{
-        data,
-        data::{
-            ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
-            Mismatch, MockDefinition, MockServerHttpResponse, RequestRequirements,
-        },
+    common::data,
+    server::{
+        persistence::{deserialize_mock_defs_from_yaml, serialize_mock_defs_to_yaml},
+        state::Error::ValidationError,
+    },
+};
+use crate::{
+    common::data::{
+        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
+        ForwardingRuleConfig, Mismatch, MockDefinition, MockServerHttpResponse, ProxyRuleConfig,
+        RecordingRuleConfig, RequestRequirements,
     },
     prelude::HttpMockRequest,
     server::{
         matchers,
-        matchers::{all, Matcher},
-        state::Error::{BodyMethodInvalid, DataConversionError, StaticMockError, ValidationError},
+        matchers::Matcher,
+        state::Error::{BodyMethodInvalid, DataConversionError, StaticMockError},
     },
 };
-
-#[cfg(feature = "record")]
-use crate::server::persistence::{deserialize_mock_defs_from_yaml, serialize_mock_defs_to_yaml};
-
-use crate::common::data::{ForwardingRuleConfig, ProxyRuleConfig, RecordingRuleConfig};
-use bytes::Bytes;
-use std::{
-    collections::BTreeMap,
-    convert::{TryFrom, TryInto},
-    sync::{Arc, Mutex},
-    time::Duration,
-};
-use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -1,14 +1,3 @@
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls_pki_types::pem::PemObject;
-
-use crate::server::tls::Error::{CaCertificateError, GenerateCertificateError};
-use async_trait::async_trait;
-use rcgen::{Certificate, CertificateParams, KeyPair, SanType};
-use rustls::{
-    crypto::ring::sign::any_supported_type,
-    server::{ClientHello, ResolvesServerCert},
-    sign::CertifiedKey,
-};
 use std::{
     collections::HashMap,
     fmt::Debug,
@@ -17,7 +6,18 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 
+use async_trait::async_trait;
+use rcgen::{Certificate, CertificateParams, KeyPair, SanType};
+use rustls::{
+    crypto::ring::sign::any_supported_type,
+    pki_types::{CertificateDer, PrivateKeyDer},
+    server::{ClientHello, ResolvesServerCert},
+    sign::CertifiedKey,
+};
+use rustls_pki_types::pem::PemObject;
 use thiserror::Error;
+
+use crate::server::tls::Error::{CaCertificateError, GenerateCertificateError};
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/tests/examples/binary_body_tests.rs
+++ b/tests/examples/binary_body_tests.rs
@@ -1,5 +1,6 @@
-use httpmock::prelude::*;
 use std::io::Read;
+
+use httpmock::prelude::*;
 
 #[test]
 fn binary_body_test() {

--- a/tests/examples/custom_request_matcher_tests.rs
+++ b/tests/examples/custom_request_matcher_tests.rs
@@ -76,9 +76,10 @@ fn is_false_matcher_called_once_per_request() {
 
 #[test]
 fn dynamic_responder_test() {
+    use std::sync::Mutex;
+
     use httpmock::prelude::*;
     use reqwest::blocking::Client;
-    use std::sync::Mutex;
 
     // Arrange
     let server = MockServer::start();
@@ -116,9 +117,10 @@ fn dynamic_responder_test() {
 
 #[test]
 fn dynamic_responder_http_crate_test() {
+    use std::sync::Mutex;
+
     use httpmock::prelude::*;
     use reqwest::blocking::Client;
-    use std::sync::Mutex;
 
     // Arrange
     let server = MockServer::start();

--- a/tests/examples/delay_tests.rs
+++ b/tests/examples/delay_tests.rs
@@ -1,5 +1,6 @@
-use httpmock::prelude::*;
 use std::time::{Duration, SystemTime};
+
+use httpmock::prelude::*;
 
 #[test]
 fn delay_test() {

--- a/tests/examples/https_tests.rs
+++ b/tests/examples/https_tests.rs
@@ -23,9 +23,10 @@ async fn test_http_get_request() {
 #[cfg(feature = "remote")]
 #[tokio::test]
 async fn https_test_reqwest() {
+    use std::{fs::read, path::PathBuf};
+
     use httpmock::MockServer;
     use reqwest::{tls::Certificate, Client};
-    use std::{fs::read, path::PathBuf};
 
     // This starts up a standalone server in the background running on port 5050
     crate::with_standalone_server();

--- a/tests/examples/record_and_playback_tests.rs
+++ b/tests/examples/record_and_playback_tests.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "record")]
 use httpmock::prelude::*;
-
 #[cfg(feature = "record")]
 use reqwest::blocking::Client;
 

--- a/tests/examples/standalone_tests.rs
+++ b/tests/examples/standalone_tests.rs
@@ -1,9 +1,10 @@
 #[test]
 #[cfg(feature = "remote")]
 fn standalone_test() {
-    use crate::with_standalone_server;
     use httpmock::MockServer;
     use reqwest::blocking::Client;
+
+    use crate::with_standalone_server;
 
     // Arrange
 
@@ -34,9 +35,10 @@ fn standalone_test() {
 #[cfg(feature = "remote")]
 #[tokio::test]
 async fn async_standalone_test() {
-    use crate::with_standalone_server;
     use httpmock::MockServer;
     use reqwest::Client;
+
+    use crate::with_standalone_server;
 
     // Arrange
 
@@ -91,8 +93,9 @@ async fn async_standalone_test() {
 #[test]
 #[should_panic]
 fn unsupported_features() {
-    use crate::with_standalone_server;
     use httpmock::MockServer;
+
+    use crate::with_standalone_server;
 
     // Arrange
 
@@ -113,9 +116,10 @@ fn unsupported_features() {
 #[cfg(feature = "remote")]
 #[test]
 fn binary_body_standalone_test() {
-    use crate::with_standalone_server;
     use httpmock::MockServer;
     use reqwest::blocking::get;
+
+    use crate::with_standalone_server;
 
     // Arrange
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,6 @@
-use httpmock::server::{HttpMockServer, HttpMockServerBuilder};
 use std::{sync::Mutex, thread};
+
+use httpmock::server::{HttpMockServer, HttpMockServerBuilder};
 use tokio::task::LocalSet;
 mod examples;
 mod matchers;

--- a/tests/matchers/body.rs
+++ b/tests/matchers/body.rs
@@ -1,5 +1,6 @@
-use crate::matchers::{expect_fails_with2, SingleValueMatcherDataSet};
 use httpmock::{MockServer, When};
+
+use crate::matchers::{expect_fails_with2, SingleValueMatcherDataSet};
 
 #[test]
 fn body() {

--- a/tests/matchers/cookies.rs
+++ b/tests/matchers/cookies.rs
@@ -1,6 +1,7 @@
-use crate::matchers::{expect_fails_with2, MultiValueMatcherTestSet};
 use http::{HeaderMap, HeaderValue};
 use httpmock::{MockServer, When};
+
+use crate::matchers::{expect_fails_with2, MultiValueMatcherTestSet};
 
 #[test]
 #[cfg(feature = "cookies")]

--- a/tests/matchers/headers.rs
+++ b/tests/matchers/headers.rs
@@ -1,5 +1,6 @@
-use crate::matchers::{expect_fails_with2, MultiValueMatcherTestSet};
 use httpmock::{MockServer, When};
+
+use crate::matchers::{expect_fails_with2, MultiValueMatcherTestSet};
 
 #[test]
 fn header() {

--- a/tests/matchers/host.rs
+++ b/tests/matchers/host.rs
@@ -1,5 +1,6 @@
-use crate::matchers::expect_fails_with2;
 use httpmock::{MockServer, When};
+
+use crate::matchers::expect_fails_with2;
 
 #[test]
 fn path_success_table_test() {

--- a/tests/matchers/method.rs
+++ b/tests/matchers/method.rs
@@ -1,9 +1,10 @@
-use crate::matchers::expect_fails_with;
 use httpmock::{
     Method::{GET, POST},
     MockServer,
 };
 use reqwest::blocking::get;
+
+use crate::matchers::expect_fails_with;
 
 #[test]
 fn success_method() {

--- a/tests/matchers/path.rs
+++ b/tests/matchers/path.rs
@@ -1,5 +1,6 @@
-use crate::matchers::{expect_fails_with2, SingleValueMatcherDataSet};
 use httpmock::{MockServer, When};
+
+use crate::matchers::{expect_fails_with2, SingleValueMatcherDataSet};
 
 #[test]
 fn path() {

--- a/tests/matchers/port.rs
+++ b/tests/matchers/port.rs
@@ -1,6 +1,7 @@
-use crate::matchers::expect_fails_with;
 use httpmock::MockServer;
 use reqwest::blocking::get;
+
+use crate::matchers::expect_fails_with;
 
 #[test]
 fn host_tests() {

--- a/tests/matchers/query_param.rs
+++ b/tests/matchers/query_param.rs
@@ -1,5 +1,6 @@
-use crate::matchers::{expect_fails_with2, to_urlencoded_query_string, MultiValueMatcherTestSet};
 use httpmock::{MockServer, When};
+
+use crate::matchers::{expect_fails_with2, to_urlencoded_query_string, MultiValueMatcherTestSet};
 
 #[test]
 fn query_param() {

--- a/tests/matchers/scheme.rs
+++ b/tests/matchers/scheme.rs
@@ -1,6 +1,7 @@
-use crate::matchers::expect_fails_with;
 use httpmock::MockServer;
 use reqwest::blocking::get;
+
+use crate::matchers::expect_fails_with;
 
 #[test]
 fn scheme_test() {

--- a/tests/matchers/urlencoded_body.rs
+++ b/tests/matchers/urlencoded_body.rs
@@ -1,5 +1,6 @@
-use crate::matchers::{expect_fails_with2, MultiValueMatcherTestSet};
 use httpmock::{MockServer, When};
+
+use crate::matchers::{expect_fails_with2, MultiValueMatcherTestSet};
 
 #[test]
 fn form_urlencoded_tuple() {

--- a/tests/misc/extensions_test.rs
+++ b/tests/misc/extensions_test.rs
@@ -1,7 +1,8 @@
 extern crate httpmock;
 
-use self::httpmock::{prelude::*, Mock};
 use std::cell::RefCell;
+
+use self::httpmock::{prelude::*, Mock};
 
 // Test for issue https://github.com/httpmock/httpmock/issues/26
 #[test]

--- a/tests/misc/runtimes_test.rs
+++ b/tests/misc/runtimes_test.rs
@@ -19,8 +19,9 @@ fn all_runtimes_test() {
 
 #[cfg(all(feature = "proxy", feature = "https"))]
 async fn test_fn() -> u16 {
-    use crate::utils::http::get_request;
     use httpmock::prelude::*;
+
+    use crate::utils::http::get_request;
 
     // Proxy forwarder
     let server2 = MockServer::connect_async("localhost:5050").await;
@@ -58,8 +59,9 @@ async fn test_fn() -> u16 {
 
 #[cfg(all(feature = "proxy", not(any(feature = "https", feature = "standalone"))))]
 async fn test_fn() -> u16 {
-    use crate::utils::http::get_request;
     use httpmock::prelude::*;
+
+    use crate::utils::http::get_request;
 
     // Proxy forwarder
     let server2 = MockServer::connect_async("localhost:5050").await;
@@ -103,8 +105,9 @@ async fn test_fn() -> u16 {
 
 #[cfg(all(feature = "proxy", feature = "standalone", not(feature = "https")))]
 async fn test_fn() -> u16 {
-    use crate::utils::http::get_request;
     use httpmock::prelude::*;
+
+    use crate::utils::http::get_request;
 
     // Fake GitHub target
     let target_server = MockServer::connect_async("localhost:5050").await;
@@ -142,8 +145,9 @@ async fn test_fn() -> u16 {
 
 #[cfg(not(any(feature = "proxy")))]
 async fn test_fn() -> u16 {
-    use crate::utils::http::get_request;
     use httpmock::prelude::*;
+
+    use crate::utils::http::get_request;
 
     let server = MockServer::start_async().await;
     let mock = server

--- a/tests/utils/http.rs
+++ b/tests/utils/http.rs
@@ -1,5 +1,6 @@
-use reqwest::blocking::Client;
 use std::collections::HashMap;
+
+use reqwest::blocking::Client;
 use tokio::sync::oneshot;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;


### PR DESCRIPTION
remove the unused imports.

addresses 126 compiler warnings (see #209)

imports sorted and formatted using `cargo +nightly fmt -- --config imports_granularity=Crate,group_imports=StdExternalCrate`