### PR TITLE
ci: add a dedicated MSRV job and drop rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
           # Each matrix row compiles a different feature set, so each caches
           # separately.
           cache-key: ${{ matrix.name }}
-
       - run: cargo test ${{ matrix.args }}
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,25 @@ jobs:
       # integration tests and examples is checked as well.
       - run: cargo hack check --feature-powerset --depth 2 --all-targets
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      # Checks that every feature builds on the rust-version declared in
+      # Cargo.toml. Dev dependencies are exempt from the MSRV promise, so
+      # this checks the library as downstream users consume it.
+      - run: cargo hack check --rust-version --each-feature --no-dev-deps
+
   test:
     name: Test (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,18 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ""
-
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
 
       # Checks that every feature builds on the rust-version declared in
-      # Cargo.toml. Dev dependencies are exempt from the MSRV promise, so
-      # this checks the library as downstream users consume it.
+      # Cargo.toml. Dev dependencies are exempt from the MSRV.
       - run: cargo hack check --rust-version --each-feature --no-dev-deps
 
   test:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -33,11 +33,8 @@ jobs:
             rust: nightly
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-
       - run: cargo test
-
       - run: cargo test --features standalone

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.88.0"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Adds an `msrv` job (`cargo hack check --rust-version --each-feature --no-dev-deps`) that verifies every feature builds on the `rust-version` declared in `Cargo.toml`. Removes `rust-toolchain.toml`, which pinned every job and local build to one release and left current stable untested