### PR TITLE
chore: extend deny.toml license policy for the all-features graph

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -92,7 +92,11 @@ allow = [
     "MIT",
     "Apache-2.0",
     #"Apache-2.0 WITH LLVM-exception",
-    "Unicode-3.0"
+    "Unicode-3.0",
+    # Permissive licenses pulled in by the TLS stack (ring, rustls-webpki,
+    # untrusted, subtle) when the https/remote-https features are enabled.
+    "ISC",
+    "BSD-3-Clause",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -107,6 +111,9 @@ exceptions = [
     # { allow = ["BSD-3-Clause"], crate = "instant" },
     # { allow = ["CC0-1.0"], crate = "tiny-keccak" },
     # { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+    # Weak copyleft, deliberately scoped to this one crate (optional dep of
+    # the cosmetic `color` feature) instead of allowed globally.
+    { allow = ["MPL-2.0"], crate = "colored" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,


### PR DESCRIPTION
`deny.toml`'s license allowlist didn't cover the TLS dependency graph. Allows ISC and BSD-3-Clause globally (ring, rustls-webpki, untrusted, subtle) and scopes MPL-2.0 to the `colored` crate alone — an optional dependency of the cosmetic `color` feature — rather than allowing it globally.

Independent of the other PRs.