### PR TITLE
fix: select ring crypto provider explicitly for server TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # Three representative feature sets; the full power set is covered by
+      # Representative feature sets; the full power set is covered by
       # feature-matrix.yml. "standalone" already implies remote, remote-https,
       # record, proxy, http2 and cookies.
+      #
+      # "https" is tested on its own because server-side TLS must not rely on
+      # rustls' crate-feature crypto-provider auto-detection: dev-dependencies
+      # (reqwest) enable rustls' aws-lc-rs feature alongside our ring feature,
+      # making auto-detection ambiguous. all-features masks this because a
+      # remote client path installs the default provider first, so only an
+      # isolated https build exercises the failure. See rustls issue #1938.
       matrix:
         include:
           - name: default
             args: ""
+          - name: https
+            args: --no-default-features --features https
           - name: standalone
             args: --features standalone
           - name: all-features

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -336,9 +336,17 @@ where
 {
     // Build TLS acceptor inline for this connection
     let cert_resolver = server.config.https.cert_resolver_factory.build(authority);
-    let mut server_config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_cert_resolver(cert_resolver);
+    // Select the ring crypto provider explicitly rather than relying on
+    // `ServerConfig::builder`'s crate-feature auto-detection: dev-dependencies
+    // (e.g. reqwest) can enable rustls' `aws-lc-rs` feature alongside our `ring`
+    // feature, which makes auto-detection ambiguous and panics.
+    // See https://github.com/rustls/rustls/issues/1938
+    let mut server_config =
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .map_err(|e| Error::TlsError(format!("cannot build TLS server config: {:?}", e)))?
+            .with_no_client_auth()
+            .with_cert_resolver(cert_resolver);
 
     server_config.alpn_protocols = vec![
         #[cfg(feature = "http2")]


### PR DESCRIPTION
## Problem

The nightly / master-push Feature Matrix ([failing run](https://github.com/httpmock/httpmock/actions/runs/29079481614)) failed on the `--no-default-features --features https` and `--features https,remote` power-set cells with:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

`serve_tls_connection` builds its `ServerConfig` via `ServerConfig::builder()`, which uses rustls' `get_default_or_install_from_crate_features()`. That auto-detection panics unless *exactly one* of the `ring` / `aws-lc-rs` rustls features is enabled. In test builds, the `reqwest` dev-dependency enables `rustls/aws-lc-rs` while our `https` feature enables `rustls/ring`, so both providers are compiled in and auto-detection is ambiguous.

## Fix

Build the `ServerConfig` with an explicit `ring` provider (`builder_with_provider`), so the server-side TLS path no longer depends on ambiguous crate-feature unification — mirroring how the client path in `common/http.rs` already installs `ring` explicitly.

## Why the fast lane missed it

`cargo test --all-features` **passes** on the pre-fix code: when `remote`/`remote-https` is active, httpmock's own client installs the `ring` provider as the process-wide default early, so the server builder finds it and never hits the ambiguous path. The bug only surfaces when server TLS runs *without* a remote client path — i.e. the isolated `https` cells that only the deep matrix runs.

To close that gap pre-merge, this PR also adds an isolated `https` row to the fast CI lane's test matrix. It would have caught this specific regression on the dependency-bump PR rather than post-merge on master.

## Verification

- `cargo test --no-default-features --features https` — all example tests pass (were panicking before)
- `cargo test --no-default-features --features https,remote` — pass
- `cargo test --all-features` — pass (unchanged)