### PR TITLE
refactor: remove dead code and drop the url dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde_regex = "1"
 base64 = "0.22"
 regex = "1"
 tracing = { version = "0.1", features = ["log"] }
-url = "2"
 stringmetrics = "2"
 assert-json-diff = "2"
 async-trait = "0.1"

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -2,7 +2,6 @@ extern crate serde_regex;
 
 use std::{
     cmp::Ordering,
-    collections::HashMap,
     convert::{TryFrom, TryInto},
     fmt,
     fmt::Debug,
@@ -16,7 +15,6 @@ use bytes::Bytes;
 use headers::{Cookie, HeaderMapExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use url::Url;
 
 use crate::{
     common::{
@@ -237,28 +235,14 @@ impl HttpMockRequest {
         self.headers.as_ref()
     }
 
-    pub fn query_params_map(&self) -> HashMap<String, String> {
-        self.query_params().into_iter().collect()
-    }
-
     pub fn query_params(&self) -> Vec<(String, String)> {
-        // There doesn't seem to be a way to just parse Query string with `url` crate, so we're
-        // prefixing a dummy URL for parsing.
-        let url = format!("http://dummy?{}", self.uri().query().unwrap_or(""));
-        let url = Url::parse(&url).unwrap();
-
-        url.query_pairs()
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
+            .into_owned()
             .collect()
     }
 
     pub fn query_param_length(&self) -> usize {
-        // There doesn't seem to be a way to just parse Query string with `url` crate, so we're
-        // prefixing a dummy URL for parsing.
-        let url = format!("http://dummy?{}", self.uri().query().unwrap_or(""));
-        let url = Url::parse(&url).unwrap();
-
-        url.query_pairs().count()
+        form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes()).count()
     }
 
     pub fn body(&self) -> &HttpMockBytes {
@@ -310,10 +294,6 @@ impl HttpMockRequest {
         }
 
         Ok(result)
-    }
-
-    pub fn to_http_request(&self) -> http::Request<Bytes> {
-        http::Request::<Bytes>::from(self)
     }
 }
 
@@ -1599,7 +1579,7 @@ impl TryInto<MockDefinition> for StaticMockDefinition {
                     self.when.body_suffix_not,
                     self.when.body_suffix_not_base64,
                 ),
-                body_matches: from_pattern_vec(self.when.body_matches),
+                body_matches: self.when.body_matches,
 
                 // JSON Body-related fields
                 json_body: self.when.json_body,
@@ -1665,10 +1645,6 @@ fn from_method_vec(value: Option<Vec<Method>>) -> Option<Vec<String>> {
     value.map(|vec| vec.iter().map(|m| m.to_string()).collect())
 }
 
-fn from_pattern_vec(patterns: Option<Vec<HttpMockRegex>>) -> Option<Vec<HttpMockRegex>> {
-    patterns.map(|vec| vec.to_vec())
-}
-
 fn from_name_value_string_pair_vec(
     kvp: Option<Vec<NameValueStringPair>>,
 ) -> Option<Vec<(String, String)>> {
@@ -1681,14 +1657,6 @@ fn from_name_value_pattern_pair_vec(
     kvp.map(|vec| {
         vec.into_iter()
             .map(|pair| (pair.name, pair.value))
-            .collect()
-    })
-}
-
-fn from_string_pair_vec(vec: Option<Vec<(String, String)>>) -> Option<Vec<NameValueStringPair>> {
-    vec.map(|vec| {
-        vec.into_iter()
-            .map(|(name, value)| NameValueStringPair { name, value })
             .collect()
     })
 }
@@ -1888,11 +1856,11 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
                 path_suffix: value.request.path_suffix,
                 path_prefix_not: value.request.path_prefix_not,
                 path_suffix_not: value.request.path_suffix_not,
-                path_matches: from_pattern_vec(value.request.path_matches),
+                path_matches: value.request.path_matches,
 
                 // Header-related fields
-                header: from_string_pair_vec(value.request.header),
-                header_not: from_string_pair_vec(value.request.header_not),
+                header: to_name_value_string_pair_vec(value.request.header),
+                header_not: to_name_value_string_pair_vec(value.request.header_not),
                 header_exists: value.request.header_exists,
                 header_missing: value.request.header_missing,
                 header_contains: to_name_value_string_pair_vec(value.request.header_includes),
@@ -1905,8 +1873,8 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
                 header_count: to_key_value_pattern_count_triple_vec(value.request.header_count),
 
                 // Cookie-related fields
-                cookie: from_string_pair_vec(value.request.cookie),
-                cookie_not: from_string_pair_vec(value.request.cookie_not),
+                cookie: to_name_value_string_pair_vec(value.request.cookie),
+                cookie_not: to_name_value_string_pair_vec(value.request.cookie_not),
                 cookie_exists: value.request.cookie_exists,
                 cookie_missing: value.request.cookie_missing,
                 cookie_contains: to_name_value_string_pair_vec(value.request.cookie_includes),
@@ -1920,8 +1888,8 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
                 cookie_count: to_key_value_pattern_count_triple_vec(value.request.cookie_count),
 
                 // Query Parameter-related fields
-                query_param: from_string_pair_vec(value.request.query_param),
-                query_param_not: from_string_pair_vec(value.request.query_param_not),
+                query_param: to_name_value_string_pair_vec(value.request.query_param),
+                query_param_not: to_name_value_string_pair_vec(value.request.query_param_not),
                 query_param_exists: value.request.query_param_exists,
                 query_param_missing: value.request.query_param_missing,
                 query_param_contains: to_name_value_string_pair_vec(
@@ -1962,7 +1930,7 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
                 body_prefix_not_base64: request_body_prefix_not_base64,
                 body_suffix_not: request_body_suffix_not,
                 body_suffix_not_base64: request_body_suffix_not_base64,
-                body_matches: from_pattern_vec(value.request.body_matches),
+                body_matches: value.request.body_matches,
 
                 // JSON Body-related fields
                 json_body: value.request.json_body,
@@ -1971,8 +1939,10 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
                 json_body_excludes: value.request.json_body_excludes,
 
                 // Form URL-encoded fields
-                form_urlencoded_tuple: from_string_pair_vec(value.request.form_urlencoded_tuple),
-                form_urlencoded_tuple_not: from_string_pair_vec(
+                form_urlencoded_tuple: to_name_value_string_pair_vec(
+                    value.request.form_urlencoded_tuple,
+                ),
+                form_urlencoded_tuple_not: to_name_value_string_pair_vec(
                     value.request.form_urlencoded_tuple_not,
                 ),
                 form_urlencoded_key_exists: value.request.form_urlencoded_tuple_exists,
@@ -2005,7 +1975,7 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
             },
             then: StaticHTTPResponse {
                 status: value.response.status,
-                header: from_string_pair_vec(value.response.headers),
+                header: to_name_value_string_pair_vec(value.response.headers),
                 body: response_body,
                 body_base64: response_body_base64,
                 // Reason for the cast to u64: The Duration::as_millis method returns the total

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -174,60 +174,6 @@ impl HttpMockBytes {
         self.0.is_empty()
     }
 
-    /// Checks if the byte slice is blank (empty or only contains ASCII whitespace).
-    ///
-    /// # Returns
-    /// `true` if the byte slice is blank, otherwise `false`.
-    pub fn is_blank(&self) -> bool {
-        self.is_empty() || self.0.iter().all(|&b| b.is_ascii_whitespace())
-    }
-
-    /// Checks if the byte slice contains the specified substring.
-    ///
-    /// # Arguments
-    /// * `substring` - The substring to search for.
-    ///
-    /// # Returns
-    /// `true` if the substring is found, otherwise `false`.
-    pub fn contains_str(&self, substring: &str) -> bool {
-        if substring.is_empty() {
-            return true;
-        }
-
-        self.0
-            .as_ref()
-            .windows(substring.len())
-            .any(|window| window == substring.as_bytes())
-    }
-
-    /// Checks if the byte slice contains the specified byte slice.
-    ///
-    /// # Arguments
-    /// * `slice` - The byte slice to search for.
-    ///
-    /// # Returns
-    /// `true` if the byte slice is found, otherwise `false`.
-    pub fn contains_slice(&self, slice: &[u8]) -> bool {
-        self.0
-            .as_ref()
-            .windows(slice.len())
-            .any(|window| window == slice)
-    }
-
-    /// Checks if the byte slice contains the specified `Vec<u8>`.
-    ///
-    /// # Arguments
-    /// * `vec` - The vector to search for.
-    ///
-    /// # Returns
-    /// `true` if the vector is found, otherwise `false`.
-    pub fn contains_vec(&self, vec: &Vec<u8>) -> bool {
-        self.0
-            .as_ref()
-            .windows(vec.len())
-            .any(|window| window == vec.as_slice())
-    }
-
     /// Converts the bytes to a UTF-8 string, potentially lossy.
     /// Tries to parse input as a UTF-8 string first to avoid copying and creating an owned instance.
     /// If the bytes are not valid UTF-8, it creates a lossy string by replacing invalid characters

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -30,7 +30,6 @@ pub struct HttpsConfigBuilder {
     ca_key: Option<String>,
     ca_cert_path: Option<PathBuf>,
     ca_key_path: Option<PathBuf>,
-    enable_https: Option<bool>,
     cert_resolver_factory: Option<Arc<dyn CertificateResolverFactory + Send + Sync>>,
 }
 
@@ -43,24 +42,21 @@ impl HttpsConfigBuilder {
             ca_cert_path: None,
             ca_key_path: None,
             cert_resolver_factory: None,
-            enable_https: None,
         }
     }
 
     /// Validates the HTTPS configuration to ensure no conflicting settings are present.
     fn validate(&self) -> Result<(), Box<dyn Error>> {
-        if self.enable_https.unwrap_or(true) {
-            let has_ca_cert = self.ca_cert.is_some() || self.ca_key.is_some();
-            let has_ca_cert_path = self.ca_cert_path.is_some() || self.ca_key_path.is_some();
-            let has_cert_generator = self.cert_resolver_factory.is_some();
+        let has_ca_cert = self.ca_cert.is_some() || self.ca_key.is_some();
+        let has_ca_cert_path = self.ca_cert_path.is_some() || self.ca_key_path.is_some();
+        let has_cert_generator = self.cert_resolver_factory.is_some();
 
-            if has_ca_cert && has_ca_cert_path {
-                return Err("A CA certificate and a CA certificate path have both been configured. Please choose only one method.".into());
-            }
+        if has_ca_cert && has_ca_cert_path {
+            return Err("A CA certificate and a CA certificate path have both been configured. Please choose only one method.".into());
+        }
 
-            if (has_ca_cert || has_ca_cert_path) && has_cert_generator {
-                return Err("Both a CA certificate and a certificate generator were configured. Please use only one of them.".into());
-            }
+        if (has_ca_cert || has_ca_cert_path) && has_cert_generator {
+            return Err("Both a CA certificate and a certificate generator were configured. Please use only one of them.".into());
         }
 
         Ok(())
@@ -134,14 +130,6 @@ impl HttpsConfigBuilder {
         self.cert_resolver_factory = generator;
         self
     }
-
-    /// Enables or disables HTTPS.
-    ///
-    /// # Parameters
-    /// - `enable`: An optional boolean to enable or disable HTTPS.
-    ///
-    /// # Returns
-    /// A modified `HttpsConfigBuilder` instance for method chaining.
 
     /// Builds the `MockServerHttpsConfig` with the current settings.
     ///


### PR DESCRIPTION
## What

Removes items with zero callers anywhere in the crate (src, tests, doc examples):

- `HttpMockBytes::{is_blank, contains_str, contains_slice, contains_vec}`
- `HttpMockRequest::{query_params_map, to_http_request}`
- the dead `enable_https` field on `HttpsConfigBuilder` — it was only ever `None`, guarded an unreachable `validate()` branch, and had an orphaned doc comment for an enable/disable method that was never implemented
- duplicate private converters in `data.rs` (`from_string_pair_vec` was byte-for-byte identical to `to_name_value_string_pair_vec`; `from_pattern_vec` was a needless clone)

Also switches `query_params()` / `query_param_length()` to parse the query string with `form_urlencoded` directly instead of the `format!("http://dummy?{}")` + `Url::parse` workaround — which removes the last use of the `url` crate, so the dependency is dropped.

## Semver note

`HttpMockRequest` is re-exported at the crate root and is passed to user-provided matcher closures, so the removed `pub` methods were technically reachable downstream (e.g. `req.body().contains_str(..)`). Nothing in this repo uses them, but strictly this is API-trimming — flagging it so you can decide whether it should wait for a 0.9 release.

## Overlap note

The private-converter cleanup in `data.rs` also appears in #247; the hunks are identical, so the PRs merge cleanly in either order.

## Verification

Full `cargo test --all-features` suite passes locally, including all 138 doctests (which proves no doc example referenced the removed items).
