### PR TITLE
Expose Default Certificate Constants

### DIFF
--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -18,8 +18,8 @@ use crate::server::{
     tls::{CertificateResolverFactory, GeneratingCertificateResolverFactory},
 };
 
-const DEFAULT_CA_PRIVATE_KEY: &str = include_str!("../../certs/ca.key");
-const DEFAULT_CA_CERTIFICATE: &str = include_str!("../../certs/ca.pem");
+pub const DEFAULT_CA_PRIVATE_KEY: &str = include_str!("../../certs/ca.key");
+pub const DEFAULT_CA_CERTIFICATE: &str = include_str!("../../certs/ca.pem");
 
 /// The Builder streamlines the configuration process, automatically setting up defaults and
 /// handling dependency injection for the mock server. It consolidates configuration parameters,

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -18,7 +18,9 @@ use crate::server::{
     tls::{CertificateResolverFactory, GeneratingCertificateResolverFactory},
 };
 
+#[cfg(feature = "https")]
 pub const DEFAULT_CA_PRIVATE_KEY: &str = include_str!("../../certs/ca.key");
+#[cfg(feature = "https")]
 pub const DEFAULT_CA_CERTIFICATE: &str = include_str!("../../certs/ca.pem");
 
 /// The Builder streamlines the configuration process, automatically setting up defaults and

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,7 +12,7 @@ mod persistence;
 #[cfg(feature = "https")]
 mod tls;
 
-pub use builder::HttpMockServerBuilder;
+pub use builder::{HttpMockServerBuilder, DEFAULT_CA_PRIVATE_KEY, DEFAULT_CA_CERTIFICATE};
 pub use server::Error;
 
 use crate::server::{handler::HttpMockHandler, server::MockServer, state::HttpMockStateManager};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,7 +12,9 @@ mod persistence;
 #[cfg(feature = "https")]
 mod tls;
 
-pub use builder::{HttpMockServerBuilder, DEFAULT_CA_PRIVATE_KEY, DEFAULT_CA_CERTIFICATE};
+pub use builder::HttpMockServerBuilder;
+#[cfg(feature = "https")]
+pub use builder::{DEFAULT_CA_CERTIFICATE, DEFAULT_CA_PRIVATE_KEY};
 pub use server::Error;
 
 use crate::server::{handler::HttpMockHandler, server::MockServer, state::HttpMockStateManager};


### PR DESCRIPTION
If you control the TLS connection chain, there's no need to [add a test certificate to the machine keychain](https://github.com/httpmock/httpmock/blob/74db108b42bb1648b48928637adc7ec817bb0bf1/docs/website/src/content/docs/server/https.mdx#L28). Instead, if the library simply exposed the already existing constants, these could be turned into a `Certificate` using `tokio_native_tls::native_tls::Certificate::from_pem`, which could then be fed into `tokio_native_tls::native_tls::TlsConnector::builder().add_root_certificate` inside a test, which is more convenient.