### PR TITLE
Replace Rc<Cell> builders with mutable references

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "record")]
 use std::path::{Path, PathBuf};
-use std::{cell::Cell, rc::Rc};
 
 #[cfg(feature = "record")]
 use bytes::Bytes;
@@ -275,20 +274,18 @@ impl<'a> Recording<'a> {
     }
 }
 
-pub struct ForwardingRuleBuilder {
-    pub(crate) request_requirements: Rc<Cell<RequestRequirements>>,
-    pub(crate) headers: Rc<Cell<Vec<(String, String)>>>,
+pub struct ForwardingRuleBuilder<'a> {
+    pub(crate) request_requirements: &'a mut RequestRequirements,
+    pub(crate) headers: &'a mut Vec<(String, String)>,
 }
 
-impl ForwardingRuleBuilder {
+impl<'a> ForwardingRuleBuilder<'a> {
     pub fn add_request_header<Key: Into<String>, Value: Into<String>>(
         self,
         key: Key,
         value: Value,
     ) -> Self {
-        let mut headers = self.headers.take();
-        headers.push((key.into(), value.into()));
-        self.headers.set(headers);
+        self.headers.push((key.into(), value.into()));
         self
     }
 
@@ -297,27 +294,25 @@ impl ForwardingRuleBuilder {
         WhenSpecFn: FnOnce(When),
     {
         when(When {
-            expectations: self.request_requirements.clone(),
+            expectations: self.request_requirements,
         });
         self
     }
 }
 
-pub struct ProxyRuleBuilder {
+pub struct ProxyRuleBuilder<'a> {
     // TODO: These fields are visible to the user, make them not public
-    pub(crate) request_requirements: Rc<Cell<RequestRequirements>>,
-    pub(crate) headers: Rc<Cell<Vec<(String, String)>>>,
+    pub(crate) request_requirements: &'a mut RequestRequirements,
+    pub(crate) headers: &'a mut Vec<(String, String)>,
 }
 
-impl ProxyRuleBuilder {
+impl<'a> ProxyRuleBuilder<'a> {
     pub fn add_request_header<Key: Into<String>, Value: Into<String>>(
         self,
         key: Key,
         value: Value,
     ) -> Self {
-        let mut headers = self.headers.take();
-        headers.push((key.into(), value.into()));
-        self.headers.set(headers);
+        self.headers.push((key.into(), value.into()));
         self
     }
 
@@ -326,22 +321,20 @@ impl ProxyRuleBuilder {
         WhenSpecFn: FnOnce(When),
     {
         when(When {
-            expectations: self.request_requirements.clone(),
+            expectations: self.request_requirements,
         });
 
         self
     }
 }
 
-pub struct RecordingRuleBuilder {
-    pub config: Rc<Cell<RecordingRuleConfig>>,
+pub struct RecordingRuleBuilder<'a> {
+    pub config: &'a mut RecordingRuleConfig,
 }
 
-impl RecordingRuleBuilder {
+impl<'a> RecordingRuleBuilder<'a> {
     pub fn record_request_header<IntoString: Into<String>>(self, header: IntoString) -> Self {
-        let mut config = self.config.take();
-        config.record_headers.push(header.into());
-        self.config.set(config);
+        self.config.record_headers.push(header.into());
         self
     }
 
@@ -349,11 +342,9 @@ impl RecordingRuleBuilder {
         self,
         headers: Vec<IntoString>,
     ) -> Self {
-        let mut config = self.config.take();
-        config
+        self.config
             .record_headers
             .extend(headers.into_iter().map(Into::into));
-        self.config.set(config);
         self
     }
 
@@ -361,26 +352,15 @@ impl RecordingRuleBuilder {
     where
         WhenSpecFn: FnOnce(When),
     {
-        let mut config = self.config.take();
-
-        let request_requirements = Rc::new(Cell::new(config.request_requirements));
-
         when(When {
-            expectations: request_requirements.clone(),
+            expectations: &mut self.config.request_requirements,
         });
-
-        config.request_requirements = request_requirements.take();
-
-        self.config.set(config);
 
         self
     }
 
     pub fn record_response_delays(self, record: bool) -> Self {
-        let mut config = self.config.take();
-        config.record_response_delays = record;
-        self.config.set(config);
-
+        self.config.record_response_delays = record;
         self
     }
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,10 +1,8 @@
 #[cfg(feature = "record")]
 use std::path::PathBuf;
 use std::{
-    cell::Cell,
     future::pending,
     net::SocketAddr,
-    rc::Rc,
     sync::{Arc, LazyLock},
     thread,
 };
@@ -422,15 +420,15 @@ impl MockServer {
     where
         SpecFn: FnOnce(When, Then),
     {
-        let req = Rc::new(Cell::new(RequestRequirements::new()));
-        let res = Rc::new(Cell::new(MockServerHttpResponse::new()));
+        let mut req = RequestRequirements::new();
+        let mut res = MockServerHttpResponse::new();
 
         spec_fn(
             When {
-                expectations: req.clone(),
+                expectations: &mut req,
             },
             Then {
-                response_template: res.clone(),
+                response_template: &mut res,
             },
         );
 
@@ -439,8 +437,8 @@ impl MockServer {
             .as_ref()
             .unwrap()
             .create_mock(&MockDefinition {
-                request: req.take(),
-                response: res.take(),
+                request: req,
+                response: res,
             })
             .await
             .expect("Cannot deserialize mock server response");
@@ -635,12 +633,12 @@ impl MockServer {
         ForwardingRuleBuilderFn: FnOnce(ForwardingRuleBuilder),
         IntoString: Into<String>,
     {
-        let headers = Rc::new(Cell::new(Vec::new()));
-        let req = Rc::new(Cell::new(RequestRequirements::new()));
+        let mut headers = Vec::new();
+        let mut req = RequestRequirements::new();
 
         rule(ForwardingRuleBuilder {
-            headers: headers.clone(),
-            request_requirements: req.clone(),
+            headers: &mut headers,
+            request_requirements: &mut req,
         });
 
         let response = self
@@ -649,8 +647,8 @@ impl MockServer {
             .unwrap()
             .create_forwarding_rule(ForwardingRuleConfig {
                 target_base_url: target_base_url.into(),
-                request_requirements: req.take(),
-                request_header: headers.take(),
+                request_requirements: req,
+                request_header: headers,
             })
             .await
             .expect("Cannot deserialize mock server response");
@@ -794,12 +792,12 @@ impl MockServer {
     where
         ProxyRuleBuilderFn: FnOnce(ProxyRuleBuilder),
     {
-        let headers = Rc::new(Cell::new(Vec::new()));
-        let req = Rc::new(Cell::new(RequestRequirements::new()));
+        let mut headers = Vec::new();
+        let mut req = RequestRequirements::new();
 
         rule(ProxyRuleBuilder {
-            headers: headers.clone(),
-            request_requirements: req.clone(),
+            headers: &mut headers,
+            request_requirements: &mut req,
         });
 
         let response = self
@@ -807,8 +805,8 @@ impl MockServer {
             .as_ref()
             .unwrap()
             .create_proxy_rule(ProxyRuleConfig {
-                request_requirements: req.take(),
-                request_header: headers.take(),
+                request_requirements: req,
+                request_header: headers,
             })
             .await
             .expect("Cannot deserialize mock server response");
@@ -993,21 +991,21 @@ impl MockServer {
     where
         RecordingRuleBuilderFn: FnOnce(RecordingRuleBuilder),
     {
-        let config = Rc::new(Cell::new(RecordingRuleConfig {
+        let mut config = RecordingRuleConfig {
             request_requirements: RequestRequirements::new(),
             record_headers: Vec::new(),
             record_response_delays: false,
-        }));
+        };
 
         rule(RecordingRuleBuilder {
-            config: config.clone(),
+            config: &mut config,
         });
 
         let response = self
             .server_adapter
             .as_ref()
             .unwrap()
-            .create_recording(config.take())
+            .create_recording(config)
             .await
             .expect("Cannot deserialize mock server response");
 

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -1,6 +1,4 @@
-use std::{
-    cell::Cell, convert::TryInto, path::Path, rc::Rc, str::FromStr, sync::Arc, time::Duration,
-};
+use std::{convert::TryInto, path::Path, str::FromStr, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use serde::Serialize;
@@ -9,7 +7,7 @@ use serde_json::Value;
 use crate::{
     common::{
         data::{MockServerHttpResponse, RequestRequirements},
-        util::{get_test_resource_file_path, update_cell, HttpMockBytes},
+        util::{get_test_resource_file_path, HttpMockBytes},
     },
     prelude::{HttpMockRequest, HttpMockResponse},
     Method, Regex,
@@ -28,11 +26,11 @@ fn push_to<T>(opt: &mut Option<Vec<T>>, value: T) {
 /// These specifications determine whether a request matches the mock setup and should be handled accordingly.
 /// This structure is part of the setup process in creating a mock server, typically used before defining the response
 /// behavior with a `Then` structure.
-pub struct When {
-    pub(crate) expectations: Rc<Cell<RequestRequirements>>,
+pub struct When<'a> {
+    pub(crate) expectations: &'a mut RequestRequirements,
 }
 
-impl When {
+impl<'a> When<'a> {
     /// Configures the mock server to respond to any incoming request, regardless of the URL path,
     /// query parameters, headers, or method.
     ///
@@ -129,9 +127,7 @@ impl When {
         let scheme = scheme
             .try_into()
             .expect("cannot convert scheme into a string");
-        update_cell(&self.expectations, |e| {
-            e.scheme = Some(scheme);
-        });
+        self.expectations.scheme = Some(scheme);
         self
     }
     // @docs-group: Scheme
@@ -182,9 +178,7 @@ impl When {
         let scheme = scheme
             .try_into()
             .expect("cannot convert scheme into a string");
-        update_cell(&self.expectations, |e| {
-            e.scheme_not = Some(scheme);
-        });
+        self.expectations.scheme_not = Some(scheme);
         self
     }
     // @docs-group: Scheme
@@ -235,7 +229,7 @@ impl When {
             .try_into()
             .expect("cannot convert method into httpmock::Method");
 
-        update_cell(&self.expectations, |e| e.method = Some(method.to_string()));
+        self.expectations.method = Some(method.to_string());
         self
     }
     // @docs-group: Method
@@ -279,9 +273,7 @@ impl When {
     /// The updated `When` instance to allow for method chaining.
     ///
     pub fn method_not<IntoMethod: Into<Method>>(self, method: IntoMethod) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.method_not, method.into().to_string())
-        });
+        push_to(&mut self.expectations.method_not, method.into().to_string());
 
         self
     }
@@ -327,7 +319,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| e.host = Some(host.into()));
+        self.expectations.host = Some(host.into());
         self
     }
     // @docs-group: Host
@@ -371,9 +363,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_not<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_not, host.into())
-        });
+        push_to(&mut self.expectations.host_not, host.into());
         self
     }
     // @docs-group: Host
@@ -427,9 +417,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_includes<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_contains, host.into())
-        });
+        push_to(&mut self.expectations.host_contains, host.into());
         self
     }
     // @docs-group: Host
@@ -480,9 +468,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_excludes<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_excludes, host.into())
-        });
+        push_to(&mut self.expectations.host_excludes, host.into());
         self
     }
     // @docs-group: Host
@@ -531,9 +517,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_prefix<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_prefix, host.into())
-        });
+        push_to(&mut self.expectations.host_prefix, host.into());
         self
     }
     // @docs-group: Host
@@ -582,9 +566,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_suffix<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_suffix, host.into())
-        });
+        push_to(&mut self.expectations.host_suffix, host.into());
         self
     }
     // @docs-group: Host
@@ -633,9 +615,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_prefix_not<IntoString: Into<String>>(self, prefix: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_prefix_not, prefix.into())
-        });
+        push_to(&mut self.expectations.host_prefix_not, prefix.into());
         self
     }
     // @docs-group: Host
@@ -683,9 +663,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_suffix_not<IntoString: Into<String>>(self, host: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_suffix_not, host.into())
-        });
+        push_to(&mut self.expectations.host_suffix_not, host.into());
         self
     }
     // @docs-group: Host
@@ -733,9 +711,7 @@ impl When {
     /// The updated `When` instance to enable method chaining.
     ///
     pub fn host_matches<IntoRegex: Into<Regex>>(self, regex: IntoRegex) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.host_matches, regex.into())
-        });
+        push_to(&mut self.expectations.host_matches, regex.into());
         self
     }
     // @docs-group: Host
@@ -790,7 +766,7 @@ impl When {
     {
         let port: u16 = port.try_into().expect("Port value is out of range for u16");
 
-        update_cell(&self.expectations, |e| e.port = Some(port));
+        self.expectations.port = Some(port);
         self
     }
     // @docs-group: Port
@@ -845,7 +821,7 @@ impl When {
     {
         let port: u16 = port.try_into().expect("Port value is out of range for u16");
 
-        update_cell(&self.expectations, |e| push_to(&mut e.port_not, port));
+        push_to(&mut self.expectations.port_not, port);
         self
     }
     // @docs-group: Port
@@ -887,9 +863,7 @@ impl When {
         <TryIntoString as TryInto<String>>::Error: std::fmt::Debug,
     {
         let path = path.try_into().expect("cannot convert path into a string");
-        update_cell(&self.expectations, |e| {
-            e.path = Some(path);
-        });
+        self.expectations.path = Some(path);
         self
     }
     // @docs-group: Path
@@ -933,7 +907,7 @@ impl When {
         <TryIntoString as TryInto<String>>::Error: std::fmt::Debug,
     {
         let path = path.try_into().expect("cannot convert path into string");
-        update_cell(&self.expectations, |e| push_to(&mut e.path_not, path));
+        push_to(&mut self.expectations.path_not, path);
         self
     }
     // @docs-group: Path
@@ -977,9 +951,7 @@ impl When {
         let substring = substring
             .try_into()
             .expect("cannot convert substring into string");
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.path_includes, substring)
-        });
+        push_to(&mut self.expectations.path_includes, substring);
         self
     }
     // @docs-group: Path
@@ -1023,9 +995,7 @@ impl When {
         let substring = substring
             .try_into()
             .expect("cannot convert substring into string");
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.path_excludes, substring)
-        });
+        push_to(&mut self.expectations.path_excludes, substring);
         self
     }
     // @docs-group: Path
@@ -1069,7 +1039,7 @@ impl When {
         let prefix = prefix
             .try_into()
             .expect("cannot convert prefix into string");
-        update_cell(&self.expectations, |e| push_to(&mut e.path_prefix, prefix));
+        push_to(&mut self.expectations.path_prefix, prefix);
         self
     }
     // @docs-group: Path
@@ -1113,7 +1083,7 @@ impl When {
         let suffix = suffix
             .try_into()
             .expect("cannot convert suffix into string");
-        update_cell(&self.expectations, |e| push_to(&mut e.path_suffix, suffix));
+        push_to(&mut self.expectations.path_suffix, suffix);
         self
     }
     // @docs-group: Path
@@ -1157,9 +1127,7 @@ impl When {
         let prefix = prefix
             .try_into()
             .expect("cannot convert prefix into string");
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.path_prefix_not, prefix)
-        });
+        push_to(&mut self.expectations.path_prefix_not, prefix);
         self
     }
     // @docs-group: Path
@@ -1203,9 +1171,7 @@ impl When {
         let suffix = suffix
             .try_into()
             .expect("cannot convert suffix into string");
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.path_suffix_not, suffix)
-        });
+        push_to(&mut self.expectations.path_suffix_not, suffix);
         self
     }
     // @docs-group: Path
@@ -1252,7 +1218,7 @@ impl When {
         let regex = regex
             .try_into()
             .expect("cannot convert provided value into regex");
-        update_cell(&self.expectations, |e| push_to(&mut e.path_matches, regex));
+        push_to(&mut self.expectations.path_matches, regex);
         self
     }
     // @docs-group: Path
@@ -1297,9 +1263,10 @@ impl When {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param, (name.into(), value.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param,
+            (name.into(), value.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1344,9 +1311,10 @@ impl When {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_not, (name.into(), value.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_not,
+            (name.into(), value.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1386,9 +1354,7 @@ impl When {
     /// The updated `When` instance to allow method chaining for additional configuration.
     ///
     pub fn query_param_exists<IntoString: Into<String>>(self, name: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_exists, name.into())
-        });
+        push_to(&mut self.expectations.query_param_exists, name.into());
         self
     }
     // @docs-group: Query Parameters
@@ -1428,9 +1394,7 @@ impl When {
     /// The updated `When` instance to allow method chaining for additional configuration.
     ///
     pub fn query_param_missing<IntoString: Into<String>>(self, name: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_missing, name.into())
-        });
+        push_to(&mut self.expectations.query_param_missing, name.into());
         self
     }
     // @docs-group: Query Parameters
@@ -1477,9 +1441,10 @@ impl When {
         name: KeyString,
         substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_includes, (name.into(), substring.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_includes,
+            (name.into(), substring.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1526,9 +1491,10 @@ impl When {
         name: KeyString,
         substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_excludes, (name.into(), substring.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_excludes,
+            (name.into(), substring.into()),
+        );
 
         self
     }
@@ -1575,9 +1541,10 @@ impl When {
         name: KeyString,
         prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_prefix, (name.into(), prefix.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_prefix,
+            (name.into(), prefix.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1623,9 +1590,10 @@ impl When {
         name: KeyString,
         suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_suffix, (name.into(), suffix.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_suffix,
+            (name.into(), suffix.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1671,9 +1639,10 @@ impl When {
         name: KeyString,
         prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_prefix_not, (name.into(), prefix.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_prefix_not,
+            (name.into(), prefix.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1719,9 +1688,10 @@ impl When {
         name: KeyString,
         suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_suffix_not, (name.into(), suffix.into()))
-        });
+        push_to(
+            &mut self.expectations.query_param_suffix_not,
+            (name.into(), suffix.into()),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1767,9 +1737,10 @@ impl When {
         let key_regex = key_regex.into();
         let value_regex = value_regex.into();
 
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.query_param_matches, (key_regex, value_regex))
-        });
+        push_to(
+            &mut self.expectations.query_param_matches,
+            (key_regex, value_regex),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1819,12 +1790,10 @@ impl When {
         let key_regex = key_regex.into();
         let value_regex = value_regex.into();
 
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.query_param_count,
-                (key_regex, value_regex, expected_count),
-            )
-        });
+        push_to(
+            &mut self.expectations.query_param_count,
+            (key_regex, value_regex, expected_count),
+        );
         self
     }
     // @docs-group: Query Parameters
@@ -1870,9 +1839,7 @@ impl When {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header, (name.into(), value.into()))
-        });
+        push_to(&mut self.expectations.header, (name.into(), value.into()));
         self
     }
     // @docs-group: Headers
@@ -1920,9 +1887,10 @@ impl When {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_not, (name.into(), value.into()))
-        });
+        push_to(
+            &mut self.expectations.header_not,
+            (name.into(), value.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -1963,9 +1931,7 @@ impl When {
     /// The updated `When` instance to allow method chaining for additional configuration.
     ///
     pub fn header_exists<IntoString: Into<String>>(self, name: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_exists, name.into())
-        });
+        push_to(&mut self.expectations.header_exists, name.into());
         self
     }
     // @docs-group: Headers
@@ -2007,9 +1973,7 @@ impl When {
     /// The updated `When` instance to allow method chaining for additional configuration.
     ///
     pub fn header_missing<IntoString: Into<String>>(self, name: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_missing, name.into())
-        });
+        push_to(&mut self.expectations.header_missing, name.into());
         self
     }
     // @docs-group: Headers
@@ -2057,9 +2021,10 @@ impl When {
         name: KeyString,
         substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_includes, (name.into(), substring.into()))
-        });
+        push_to(
+            &mut self.expectations.header_includes,
+            (name.into(), substring.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2107,9 +2072,10 @@ impl When {
         name: KeyString,
         substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_excludes, (name.into(), substring.into()))
-        });
+        push_to(
+            &mut self.expectations.header_excludes,
+            (name.into(), substring.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2157,9 +2123,10 @@ impl When {
         name: KeyString,
         prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_prefix, (name.into(), prefix.into()))
-        });
+        push_to(
+            &mut self.expectations.header_prefix,
+            (name.into(), prefix.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2207,9 +2174,10 @@ impl When {
         name: KeyString,
         suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_suffix, (name.into(), suffix.into()))
-        });
+        push_to(
+            &mut self.expectations.header_suffix,
+            (name.into(), suffix.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2257,9 +2225,10 @@ impl When {
         name: KeyString,
         prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_prefix_not, (name.into(), prefix.into()))
-        });
+        push_to(
+            &mut self.expectations.header_prefix_not,
+            (name.into(), prefix.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2307,9 +2276,10 @@ impl When {
         name: KeyString,
         suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_suffix_not, (name.into(), suffix.into()))
-        });
+        push_to(
+            &mut self.expectations.header_suffix_not,
+            (name.into(), suffix.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2358,12 +2328,10 @@ impl When {
         key_regex: KeyString,
         value_regex: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.header_matches,
-                (key_regex.into(), value_regex.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.header_matches,
+            (key_regex.into(), value_regex.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -2434,9 +2402,10 @@ impl When {
             .try_into()
             .expect("cannot convert key to regex");
 
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.header_count, (key_pattern, value_pattern, count))
-        });
+        push_to(
+            &mut self.expectations.header_count,
+            (key_pattern, value_pattern, count),
+        );
         self
     }
     // @docs-group: Headers
@@ -2483,9 +2452,7 @@ impl When {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie, (name.into(), value.into()))
-        });
+        push_to(&mut self.expectations.cookie, (name.into(), value.into()));
         self
     }
     // @docs-group: Cookies
@@ -2532,9 +2499,10 @@ impl When {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_not, (name.into(), value.into()))
-        });
+        push_to(
+            &mut self.expectations.cookie_not,
+            (name.into(), value.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2576,9 +2544,7 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn cookie_exists<IntoString: Into<String>>(self, name: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_exists, name.into())
-        });
+        push_to(&mut self.expectations.cookie_exists, name.into());
         self
     }
     // @docs-group: Cookies
@@ -2620,9 +2586,7 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn cookie_missing<IntoString: Into<String>>(self, name: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_missing, name.into())
-        });
+        push_to(&mut self.expectations.cookie_missing, name.into());
         self
     }
     // @docs-group: Cookies
@@ -2669,12 +2633,10 @@ impl When {
         name: KeyString,
         value_substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.cookie_includes,
-                (name.into(), value_substring.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.cookie_includes,
+            (name.into(), value_substring.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2721,12 +2683,10 @@ impl When {
         name: KeyString,
         value_substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.cookie_excludes,
-                (name.into(), value_substring.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.cookie_excludes,
+            (name.into(), value_substring.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2773,9 +2733,10 @@ impl When {
         name: KeyString,
         value_prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_prefix, (name.into(), value_prefix.into()))
-        });
+        push_to(
+            &mut self.expectations.cookie_prefix,
+            (name.into(), value_prefix.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2822,9 +2783,10 @@ impl When {
         name: KeyString,
         value_suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_suffix, (name.into(), value_suffix.into()))
-        });
+        push_to(
+            &mut self.expectations.cookie_suffix,
+            (name.into(), value_suffix.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2871,9 +2833,10 @@ impl When {
         name: KeyString,
         value_prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_prefix_not, (name.into(), value_prefix.into()))
-        });
+        push_to(
+            &mut self.expectations.cookie_prefix_not,
+            (name.into(), value_prefix.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2920,9 +2883,10 @@ impl When {
         name: KeyString,
         value_suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.cookie_suffix_not, (name.into(), value_suffix.into()))
-        });
+        push_to(
+            &mut self.expectations.cookie_suffix_not,
+            (name.into(), value_suffix.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -2970,12 +2934,10 @@ impl When {
         key_regex: KeyRegex,
         value_regex: ValueRegex,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.cookie_matches,
-                (key_regex.into(), value_regex.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.cookie_matches,
+            (key_regex.into(), value_regex.into()),
+        );
         self
     }
     // @docs-group: Cookies
@@ -3025,12 +2987,10 @@ impl When {
         value_regex: ValueRegex,
         count: usize,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.cookie_count,
-                (key_regex.into(), value_regex.into(), count),
-            )
-        });
+        push_to(
+            &mut self.expectations.cookie_count,
+            (key_regex.into(), value_regex.into(), count),
+        );
         self
     }
     // @docs-group: Cookies
@@ -3071,9 +3031,7 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn body<IntoString: Into<String>>(self, body: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            e.body = Some(HttpMockBytes::from(Bytes::from(body.into())));
-        });
+        self.expectations.body = Some(HttpMockBytes::from(Bytes::from(body.into())));
         self
     }
     // @docs-group: Body
@@ -3114,12 +3072,10 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn body_not<IntoString: Into<String>>(self, body: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_not,
-                HttpMockBytes::from(Bytes::from(body.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_not,
+            HttpMockBytes::from(Bytes::from(body.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3160,12 +3116,10 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn body_includes<IntoString: Into<String>>(self, substring: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_includes,
-                HttpMockBytes::from(Bytes::from(substring.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_includes,
+            HttpMockBytes::from(Bytes::from(substring.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3206,12 +3160,10 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn body_excludes<IntoString: Into<String>>(self, substring: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_excludes,
-                HttpMockBytes::from(Bytes::from(substring.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_excludes,
+            HttpMockBytes::from(Bytes::from(substring.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3252,12 +3204,10 @@ impl When {
     /// # Returns
     /// The updated `When` instance to allow method chaining for additional configuration.
     pub fn body_prefix<IntoString: Into<String>>(self, prefix: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_prefix,
-                HttpMockBytes::from(Bytes::from(prefix.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_prefix,
+            HttpMockBytes::from(Bytes::from(prefix.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3298,12 +3248,10 @@ impl When {
     /// # Returns
     /// The updated `When’ instance to allow method chaining for additional configuration.
     pub fn body_suffix<IntoString: Into<String>>(self, suffix: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_suffix,
-                HttpMockBytes::from(Bytes::from(suffix.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_suffix,
+            HttpMockBytes::from(Bytes::from(suffix.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3344,12 +3292,10 @@ impl When {
     /// # Returns
     /// The updated `When’ instance to allow method chaining for additional configuration.
     pub fn body_prefix_not<IntoString: Into<String>>(self, prefix: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_prefix_not,
-                HttpMockBytes::from(Bytes::from(prefix.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_prefix_not,
+            HttpMockBytes::from(Bytes::from(prefix.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3390,12 +3336,10 @@ impl When {
     /// # Returns
     /// The updated `When’ instance to allow method chaining for additional configuration.
     pub fn body_suffix_not<IntoString: Into<String>>(self, suffix: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.body_suffix_not,
-                HttpMockBytes::from(Bytes::from(suffix.into())),
-            )
-        });
+        push_to(
+            &mut self.expectations.body_suffix_not,
+            HttpMockBytes::from(Bytes::from(suffix.into())),
+        );
         self
     }
     // @docs-group: Body
@@ -3436,9 +3380,7 @@ impl When {
     /// # Returns
     /// The updated `When’ instance to allow method chaining for additional configuration.
     pub fn body_matches<IntoRegex: Into<Regex>>(self, pattern: IntoRegex) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.body_matches, pattern.into())
-        });
+        push_to(&mut self.expectations.body_matches, pattern.into());
         self
     }
     // @docs-group: Body
@@ -3488,9 +3430,7 @@ impl When {
     /// # Returns
     /// The updated `When’ instance to allow method chaining for additional configuration.
     pub fn json_body<JsonValue: Into<Value>>(self, json_value: JsonValue) -> Self {
-        update_cell(&self.expectations, |e| {
-            e.json_body = Some(json_value.into());
-        });
+        self.expectations.json_body = Some(json_value.into());
         self
     }
     // @docs-group: Body
@@ -3618,11 +3558,9 @@ impl When {
     /// It's important that the partial JSON contains the full object hierarchy necessary to reach the target attribute.
     /// Irrelevant attributes such as `parent_attribute` and `child.other_attribute` can be omitted.
     pub fn json_body_includes<IntoString: Into<String>>(self, partial: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            let value = Value::from_str(&partial.into())
-                .expect("cannot convert JSON string to serde value");
-            push_to(&mut e.json_body_includes, value);
-        });
+        let value =
+            Value::from_str(&partial.into()).expect("cannot convert JSON string to serde value");
+        push_to(&mut self.expectations.json_body_includes, value);
         self
     }
     // @docs-group: Body
@@ -3689,11 +3627,9 @@ impl When {
     /// It's important that the partial JSON contains the full object hierarchy necessary to reach the target attribute.
     /// Irrelevant attributes such as `parent_attribute` and `child.other_attribute` in the example can be omitted.
     pub fn json_body_excludes<IntoString: Into<String>>(self, partial: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            let value = Value::from_str(&partial.into())
-                .expect("cannot convert JSON string to serde value");
-            push_to(&mut e.json_body_excludes, value);
-        });
+        let value =
+            Value::from_str(&partial.into()).expect("cannot convert JSON string to serde value");
+        push_to(&mut self.expectations.json_body_excludes, value);
         self
     }
     // @docs-group: Body
@@ -3747,9 +3683,10 @@ impl When {
         key: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.form_urlencoded_tuple, (key.into(), value.into()))
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple,
+            (key.into(), value.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -3802,9 +3739,10 @@ impl When {
         key: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.form_urlencoded_tuple_not, (key.into(), value.into()))
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_not,
+            (key.into(), value.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -3854,9 +3792,10 @@ impl When {
     /// `When`: Returns the modified `When` object with the new key existence requirement added to the
     /// `application/x-www-form-urlencoded` expectations.
     pub fn form_urlencoded_tuple_exists<IntoString: Into<String>>(self, key: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.form_urlencoded_tuple_exists, key.into())
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_exists,
+            key.into(),
+        );
         self
     }
     // @docs-group: Body
@@ -3906,9 +3845,10 @@ impl When {
     /// `When`: Returns the modified `When` object with the new key absence requirement added to the
     /// `application/x-www-form-urlencoded` expectations.
     pub fn form_urlencoded_tuple_missing<IntoString: Into<String>>(self, key: IntoString) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.form_urlencoded_tuple_missing, key.into())
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_missing,
+            key.into(),
+        );
         self
     }
     // @docs-group: Body
@@ -3963,12 +3903,10 @@ impl When {
         key: KeyString,
         substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_includes,
-                (key.into(), substring.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_includes,
+            (key.into(), substring.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4022,12 +3960,10 @@ impl When {
         key: KeyString,
         substring: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_excludes,
-                (key.into(), substring.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_excludes,
+            (key.into(), substring.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4082,12 +4018,10 @@ impl When {
         key: KeyString,
         prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_prefix,
-                (key.into(), prefix.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_prefix,
+            (key.into(), prefix.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4142,12 +4076,10 @@ impl When {
         key: KeyString,
         prefix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_prefix_not,
-                (key.into(), prefix.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_prefix_not,
+            (key.into(), prefix.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4202,12 +4134,10 @@ impl When {
         key: KeyString,
         suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_suffix,
-                (key.into(), suffix.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_suffix,
+            (key.into(), suffix.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4262,12 +4192,10 @@ impl When {
         key: KeyString,
         suffix: ValueString,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_suffix_not,
-                (key.into(), suffix.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_suffix_not,
+            (key.into(), suffix.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4325,12 +4253,10 @@ impl When {
         key_regex: KeyRegex,
         value_regex: ValueRegex,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_matches,
-                (key_regex.into(), value_regex.into()),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_matches,
+            (key_regex.into(), value_regex.into()),
+        );
         self
     }
     // @docs-group: Body
@@ -4392,12 +4318,10 @@ impl When {
         value_regex: ValueRegex,
         count: usize,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(
-                &mut e.form_urlencoded_tuple_count,
-                (key_regex.into(), value_regex.into(), count),
-            )
-        });
+        push_to(
+            &mut self.expectations.form_urlencoded_tuple_count,
+            (key_regex.into(), value_regex.into(), count),
+        );
         self
     }
     // @docs-group: Body
@@ -4486,9 +4410,7 @@ impl When {
         self,
         matcher: impl Fn(&HttpMockRequest) -> bool + Sync + Send + 'static,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.is_true, Arc::new(matcher))
-        });
+        push_to(&mut self.expectations.is_true, Arc::new(matcher));
         self
     }
     // @docs-group: Custom
@@ -4531,9 +4453,7 @@ impl When {
         self,
         matcher: impl Fn(&HttpMockRequest) -> bool + Sync + Send + 'static,
     ) -> Self {
-        update_cell(&self.expectations, |e| {
-            push_to(&mut e.is_false, Arc::new(matcher))
-        });
+        push_to(&mut self.expectations.is_false, Arc::new(matcher));
         self
     }
     // @docs-group: Custom
@@ -4586,11 +4506,11 @@ impl When {
 /// allows for detailed customization of response aspects such as status codes, headers, body
 /// content, and delays. This structure is integral to defining how the mock server behaves when
 /// it receives a request that matches the defined expectations.
-pub struct Then {
-    pub(crate) response_template: Rc<Cell<MockServerHttpResponse>>,
+pub struct Then<'a> {
+    pub(crate) response_template: &'a mut MockServerHttpResponse,
 }
 
-impl Then {
+impl<'a> Then<'a> {
     /// Configures the HTTP response status code that the mock server will return.
     ///
     /// # Parameters
@@ -4625,13 +4545,11 @@ impl Then {
     where
         <U16 as TryInto<u16>>::Error: std::fmt::Debug,
     {
-        update_cell(&self.response_template, |r| {
-            r.status = Some(
-                status
-                    .try_into()
-                    .expect("cannot parse status code to usize"),
-            );
-        });
+        self.response_template.status = Some(
+            status
+                .try_into()
+                .expect("cannot parse status code to usize"),
+        );
         self
     }
     // @docs-group: Status
@@ -4673,9 +4591,8 @@ impl Then {
     /// assert_eq!(response.text().unwrap(), "ohi!");
     /// ```
     pub fn body<SliceRef: AsRef<[u8]>>(self, body: SliceRef) -> Self {
-        update_cell(&self.response_template, |r| {
-            r.body = Some(HttpMockBytes::from(Bytes::copy_from_slice(body.as_ref())));
-        });
+        self.response_template.body =
+            Some(HttpMockBytes::from(Bytes::copy_from_slice(body.as_ref())));
         self
     }
     // @docs-group: Body
@@ -4793,9 +4710,8 @@ impl Then {
     /// assert_eq!(user["name"], "Hans");
     /// ```
     pub fn json_body<V: Into<Value>>(self, body: V) -> Self {
-        update_cell(&self.response_template, |r| {
-            r.body = Some(HttpMockBytes::from(Bytes::from(body.into().to_string())));
-        });
+        self.response_template.body =
+            Some(HttpMockBytes::from(Bytes::from(body.into().to_string())));
         self
     }
     // @docs-group: Body
@@ -4921,9 +4837,10 @@ impl Then {
         name: KeyString,
         value: ValueString,
     ) -> Self {
-        update_cell(&self.response_template, |r| {
-            push_to(&mut r.headers, (name.into(), value.into()))
-        });
+        push_to(
+            &mut self.response_template.headers,
+            (name.into(), value.into()),
+        );
         self
     }
     // @docs-group: Headers
@@ -4984,9 +4901,7 @@ impl Then {
             panic!("A delay higher than {} milliseconds is not supported.", max)
         }
 
-        update_cell(&self.response_template, |r| {
-            r.delay = Some(duration.as_millis() as u64);
-        });
+        self.response_template.delay = Some(duration.as_millis() as u64);
         self
     }
     // @docs-group: Network
@@ -5184,9 +5099,7 @@ impl Then {
     where
         F: Fn(&HttpMockRequest) -> HttpMockResponse + Send + Sync + 'static,
     {
-        update_cell(&self.response_template, |r| {
-            r.respond_with = Some(std::sync::Arc::new(f));
-        });
+        self.response_template.respond_with = Some(std::sync::Arc::new(f));
         self
     }
 }

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -1,6 +1,5 @@
 use std::{
     borrow::Cow,
-    cell::Cell,
     env,
     fs::{create_dir_all, File},
     future::Future,
@@ -18,15 +17,6 @@ use crossbeam_utils::sync::{Parker, Unparker};
 use futures_timer::Delay;
 use futures_util::{pin_mut, task::ArcWake};
 use serde::{Deserialize, Serialize};
-
-// ===============================================================================================
-// Misc
-// ===============================================================================================
-pub(crate) fn update_cell<T: Sized + Default, F: FnOnce(&mut T)>(v: &Cell<T>, f: F) {
-    let mut vv = v.take();
-    f(&mut vv);
-    v.set(vv);
-}
 
 // ===============================================================================================
 // Retry


### PR DESCRIPTION
Refactor `When` and rule builder APIs to mutate configs in place via `&mut` references, removing `Rc<Cell>` plumbing across proxy/server setup paths and deleting the now-unused `update_cell` helper.

Not sure if this would break usage. imo the risk of breakage is quite small but I need to ponder on it