### PR TITLE
breaking: use http types internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- `HttpMockRequest` now exposes borrowed `http` types, including its parsed authority. `query_params()` returns an iterator, and the redundant `*_str`, `*_vec`, `*_ref`, and `*_bytes` accessors have been removed.
+- Converting an `http::Request` into `HttpMockRequest` now uses `TryFrom`. The conversions to `http::Request<String>` and `http::Request<()>` have been removed.
+- `HttpMockResponse` now has private typed fields and no longer implements Serde. Its accessors and builder use `StatusCode`, `HeaderMap`, `HeaderName`, and `HeaderValue`; `no_body()` has been removed because responses always have a body, which is empty by default.
+
 ## Version 0.8.3
 
 Minimum supported Rust version has been raised to 1.88.

--- a/src/api/mock.rs
+++ b/src/api/mock.rs
@@ -104,7 +104,6 @@ impl<'a> Mock<'a> {
     /// ```rust
     /// use httpmock::prelude::*;
     /// use reqwest::get;
-    /// use syn::token;
     ///
     /// let rt = tokio::runtime::Runtime::new().unwrap();
     /// rt.block_on(async {

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -4917,6 +4917,7 @@ impl Then {
     /// A minimal dynamic responder that mirrors the request body value back to the client:
     ///
     /// ```rust
+    /// use http::StatusCode;
     /// use httpmock::{MockServer, HttpMockRequest, HttpMockResponse};
     /// use reqwest::blocking::Client;
     ///
@@ -4929,7 +4930,7 @@ impl Then {
     ///         let echoed_body = req.body().to_string();
     ///
     ///         HttpMockResponse::builder()
-    ///             .status(200)
+    ///             .status(StatusCode::OK)
     ///             .body(echoed_body)
     ///             .build()
     ///     });
@@ -4951,25 +4952,27 @@ impl Then {
     /// Stateful dynamic responder that increments the status code on each call:
     ///
     /// ```rust
+    /// use http::StatusCode;
     /// use httpmock::{MockServer, HttpMockRequest, HttpMockResponse};
     /// use reqwest::blocking::Client;
-    /// use std::sync::Mutex;
+    /// use std::sync::atomic::{AtomicUsize, Ordering};
     ///
     /// // Arrange
     /// let server = MockServer::start();
     ///
-    /// // Shared counter used inside the responder closure.
-    /// // Use a Mutex/RwLock/atomic because the closure runs on the server thread.
-    /// let call_count = Mutex::new(0);
+    /// let call_count = AtomicUsize::new(0);
     ///
     /// let mock = server.mock(|when, then| {
     ///     when.path("/hello");
     ///     then.respond_with(move |_req: &HttpMockRequest| {
-    ///         let mut count = call_count.lock().unwrap();
-    ///         *count += 1;
+    ///         let status = match call_count.fetch_add(1, Ordering::Relaxed) {
+    ///             0 => StatusCode::CREATED,
+    ///             1 => StatusCode::ACCEPTED,
+    ///             _ => StatusCode::NON_AUTHORITATIVE_INFORMATION,
+    ///         };
     ///
     ///         HttpMockResponse::builder()
-    ///             .status(200 + *count) // 201, 202, 203, ...
+    ///             .status(status)
     ///             .build()
     ///     });
     /// });
@@ -4995,7 +4998,8 @@ impl Then {
     /// that operate on `http::Request` and `http::Response`.
     ///
     /// ```rust
-    /// use httpmock::{MockServer, HttpMockRequest, HttpMockResponse};
+    /// use http::StatusCode;
+    /// use httpmock::{MockServer, HttpMockRequest};
     /// use reqwest::blocking::Client;
     ///
     /// let server = MockServer::start();
@@ -5003,14 +5007,16 @@ impl Then {
     /// let mock = server.mock(|when, then| {
     ///     when.method("POST").path("/echo");
     ///     then.respond_with(|req: &HttpMockRequest| {
-    ///         // Convert the HttpMockRequest to an `http` crate Request (with body)
-    ///         let http_req: http::Request<String> = req.into();
+    ///         let http_req: http::Request<bytes::Bytes> = req.into();
     ///
-    ///         // Build an `http` crate Response (auto-converted to HttpMockResponse)
     ///         http::Response::builder()
-    ///             .status(200)
-    ///             .header("content-type", "text/plain")
-    ///             .body(format!("Echo from {}: {}", http_req.uri().path(), http_req.body()))
+    ///             .status(StatusCode::OK)
+    ///             .header(http::header::CONTENT_TYPE, "text/plain")
+    ///             .body(format!(
+    ///                 "Echo from {}: {}",
+    ///                 http_req.uri().path(),
+    ///                 String::from_utf8_lossy(http_req.body())
+    ///             ))
     ///             .unwrap()
     ///             .into()
     ///     });

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -13,7 +13,11 @@ use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use bytes::Bytes;
 #[cfg(feature = "cookies")]
 use headers::{Cookie, HeaderMapExt};
-use serde::{Deserialize, Serialize};
+use http::{
+    HeaderMap, HeaderValue, Method as HttpMethod, Uri, Version,
+    uri::{Authority, Scheme},
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 pub type ResponseCallback = Arc<dyn Fn(&HttpMockRequest) -> HttpMockResponse + Send + Sync>;
@@ -45,9 +49,134 @@ pub enum Error {
     ResponseConversionError(String),
 }
 
-/// A general abstraction of an HTTP request of `httpmock`.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// A validated HTTP request received by `httpmock`.
+#[derive(Debug, Clone)]
 pub struct HttpMockRequest {
+    scheme: Scheme,
+    uri: Uri,
+    authority: RequestAuthority,
+    method: HttpMethod,
+    headers: HeaderMap,
+    version: Version,
+    body: HttpMockBytes,
+}
+
+#[derive(Debug, Clone)]
+enum RequestAuthority {
+    Uri,
+    Host(Authority),
+    None,
+}
+
+impl HttpMockRequest {
+    fn from_parts(
+        scheme: Scheme,
+        uri: Uri,
+        method: HttpMethod,
+        headers: HeaderMap,
+        version: Version,
+        body: HttpMockBytes,
+    ) -> Result<Self, Error> {
+        if let Some(uri_scheme) = uri.scheme()
+            && uri_scheme != &scheme
+        {
+            return Err(RequestConversionError(format!(
+                "request scheme {scheme} does not match URI scheme {uri_scheme}"
+            )));
+        }
+
+        let authority = match (uri.authority(), headers.get(http::header::HOST)) {
+            (Some(_), _) => RequestAuthority::Uri,
+            (None, Some(value)) => RequestAuthority::Host(
+                Authority::try_from(value.as_bytes())
+                    .map_err(|err| RequestConversionError(format!("invalid request authority: {err}")))?,
+            ),
+            (None, None) => RequestAuthority::None,
+        };
+
+        Ok(Self {
+            scheme,
+            uri,
+            authority,
+            method,
+            headers,
+            version,
+            body,
+        })
+    }
+
+    /// Returns the request URI.
+    pub fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    /// Returns the request scheme, including transport-derived fallback data for origin-form URIs.
+    pub fn scheme(&self) -> &Scheme {
+        self.uri.scheme().unwrap_or(&self.scheme)
+    }
+
+    /// Returns the request authority from the URI or `Host` header.
+    pub fn authority(&self) -> Option<&Authority> {
+        match &self.authority {
+            RequestAuthority::Uri => self.uri.authority(),
+            RequestAuthority::Host(authority) => Some(authority),
+            RequestAuthority::None => None,
+        }
+    }
+
+    /// Returns the request host without its port.
+    pub fn host(&self) -> Option<&str> {
+        self.authority().map(Authority::host)
+    }
+
+    /// Returns the explicit request port, 443 for HTTPS, or 80 for other schemes.
+    pub fn port(&self) -> u16 {
+        self.authority()
+            .and_then(|authority| authority.port_u16())
+            .unwrap_or_else(|| if self.scheme() == &Scheme::HTTPS { 443 } else { 80 })
+    }
+
+    /// Returns the request method.
+    pub fn method(&self) -> &HttpMethod {
+        &self.method
+    }
+
+    /// Returns the request headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Returns the decoded query parameter pairs in URI order.
+    pub fn query_params(&self) -> impl Iterator<Item = (std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>)> + '_ {
+        form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
+    }
+
+    /// Returns the request body.
+    pub fn body(&self) -> &HttpMockBytes {
+        &self.body
+    }
+
+    /// Returns the HTTP version.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    #[cfg(feature = "cookies")]
+    pub(crate) fn cookies(&self) -> Vec<(String, String)> {
+        let mut result = Vec::new();
+
+        if let Some(cookie) = self.headers.typed_get::<Cookie>() {
+            for (key, value) in cookie.iter() {
+                result.push((key.to_string(), value.to_string()));
+            }
+        }
+
+        result
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct HttpMockRequestWire {
     scheme: String,
     uri: String,
     method: String,
@@ -56,574 +185,429 @@ pub struct HttpMockRequest {
     body: HttpMockBytes,
 }
 
-impl HttpMockRequest {
-    pub(crate) fn new(
-        scheme: String,
-        uri: String,
-        method: String,
-        headers: Vec<(String, String)>,
-        version: String,
-        body: HttpMockBytes,
-    ) -> Self {
-        // TODO: Many fields from the struct are exposed as structures from http package to the user.
-        //  These values here are also converted to these http crate structures every call.
-        //  ==> Convert these values here into http crate structures and allow returning an error
-        //      here instead of "unwrap" all the time later (see functions below).
-        //      Convert into http crate structures once here and store the converted
-        //          values in the struct instance here rather than only String values everywhere.
-        //     This will require to make the HttpMockRequest serde compatible
-        //     (http types are not serializable by default).
-        Self {
-            scheme,
-            uri,
-            method,
+impl TryFrom<&HttpMockRequest> for HttpMockRequestWire {
+    type Error = Error;
+
+    fn try_from(request: &HttpMockRequest) -> Result<Self, Self::Error> {
+        let headers = request
+            .headers
+            .iter()
+            .map(|(name, value)| {
+                let value = value.to_str().map_err(|err| RequestConversionError(err.to_string()))?;
+                Ok((name.as_str().to_string(), value.to_string()))
+            })
+            .collect::<Result<_, Error>>()?;
+
+        Ok(Self {
+            scheme: request.scheme().as_str().to_string(),
+            uri: request.uri.to_string(),
+            method: request.method.as_str().to_string(),
             headers,
-            version,
-            body,
-        }
-    }
-
-    /// Parses and returns the URI of the request.
-    ///
-    /// # Attention
-    ///
-    /// - This method returns the full URI of the request as an `http::Uri` object.
-    /// - The URI returned by this method does not include the `Host` part. In HTTP/1.1,
-    ///   the request line typically contains only the path and query, not the full URL with the host.
-    /// - To retrieve the host, you should use the `HttpMockRequest::host` method which extracts the `Host`
-    ///   header (for HTTP/1.1) or the `:authority` pseudo-header (for HTTP/2 and HTTP/3).
-    ///
-    /// # Returns
-    ///
-    /// An `http::Uri` object representing the full URI of the request.
-    pub fn uri(&self) -> http::Uri {
-        self.uri.parse().unwrap()
-    }
-
-    /// Parses the scheme from the request.
-    ///
-    /// This function extracts the scheme (protocol) used in the request. If the request contains a relative path,
-    /// the scheme will be inferred based on how the server received the request. For instance, if the request was
-    /// sent to the server using HTTPS, the scheme will be set to "https"; otherwise, it will be set to "http".
-    ///
-    /// # Returns
-    ///
-    /// A `String` representing the scheme of the request, either "https" or "http".
-    pub fn scheme(&self) -> String {
-        let uri = self.uri();
-        if let Some(scheme) = uri.scheme() {
-            return scheme.to_string();
-        }
-
-        self.scheme.clone()
-    }
-
-    /// Returns the URI of the request as a string slice.
-    ///
-    /// # Attention
-    ///
-    /// - This method returns the full URI as a string slice.
-    /// - The URI string returned by this method does not include the `Host` part. In HTTP/1.1,
-    ///   the request line typically contains only the path and query, not the full URL with the host.
-    /// - To retrieve the host, you should use the `host` method which extracts the `Host`
-    ///   header (for HTTP/1.1) or the `:authority` pseudo-header (for HTTP/2 and HTTP/3).
-    ///
-    /// # Returns
-    ///
-    /// A string slice representing the full URI of the request.
-    pub fn uri_str(&self) -> &str {
-        self.uri.as_ref()
-    }
-
-    /// Returns the host that the request was sent to, based on the `Host` header or `:authority` pseudo-header.
-    ///
-    /// # Attention
-    ///
-    /// - This method retrieves the host from the `Host` header of the HTTP request for HTTP/1.1 requests.
-    ///   For HTTP/2 and HTTP/3 requests, it retrieves the host from the `:authority` pseudo-header.
-    /// - If you use the `HttpMockRequest::uri` method to get the full URI, note that
-    ///   the URI might not include the host part. In HTTP/1.1, the request line
-    ///   typically contains only the path and query, not the full URL.
-    ///
-    /// # Returns
-    ///
-    /// An `Option<String>` containing the host if the `Host` header or `:authority` pseudo-header is present, or
-    /// `None` if neither is found.
-    pub fn host(&self) -> Option<String> {
-        // Check the Host header first (HTTP 1.1)
-        if let Some((_, host)) = self.headers.iter().find(|(k, _)| k.eq_ignore_ascii_case("host")) {
-            return Some(host.split(':').next().unwrap().to_string());
-        }
-
-        // If Host header is not found, check the URI authority (HTTP/2 and HTTP/3)
-        let uri = self.uri();
-        if let Some(authority) = uri.authority() {
-            return Some(authority.as_str().split(':').next().unwrap().to_string());
-        }
-
-        None
-    }
-
-    /// Returns the port that the request was sent to, based on the `Host` header or `:authority` pseudo-header.
-    ///
-    /// # Attention
-    ///
-    /// 1. This method retrieves the port from the `Host` header of the HTTP request for HTTP/1.1 requests.
-    ///    For HTTP/2 and HTTP/3 requests, it retrieves the port from the `:authority` pseudo-header.
-    ///    This method attempts to parse the port as a `u16`. If the port cannot be parsed as a `u16`, this method will continue as if the port was not specified (see point 2).
-    /// 2. If the port is not specified in the `Host` header or `:authority` pseudo-header, this method will return 443 (https) or 80 (http) based on the used scheme.
-    ///
-    /// # Returns
-    ///
-    /// An `u16` containing the port if the `Host` header or `:authority` pseudo-header is present and includes a valid port,
-    /// or 443 (https) or 80 (http) based on the used scheme otherwise.
-    pub fn port(&self) -> u16 {
-        // Check the Host header first (HTTP 1.1)
-        if let Some((_, host)) = self.headers.iter().find(|(k, _)| k.eq_ignore_ascii_case("host"))
-            && let Some(port_str) = host.split(':').nth(1)
-            && let Ok(port) = port_str.parse::<u16>()
-        {
-            return port;
-        }
-
-        // If Host header is not found, check the URI authority (HTTP/2 and HTTP/3)
-        let uri = self.uri();
-        if let Some(authority) = uri.authority()
-            && let Some(port_str) = authority.as_str().split(':').nth(1)
-            && let Ok(port) = port_str.parse::<u16>()
-        {
-            return port;
-        }
-
-        if self.scheme().eq("https") {
-            return 443;
-        }
-
-        80
-    }
-
-    pub fn method(&self) -> http::Method {
-        http::Method::from_bytes(self.method.as_bytes()).unwrap()
-    }
-
-    pub fn method_str(&self) -> &str {
-        self.method.as_ref()
-    }
-
-    pub fn headers(&self) -> http::HeaderMap<http::HeaderValue> {
-        let mut header_map: http::HeaderMap<http::HeaderValue> = http::HeaderMap::new();
-        for (key, value) in &self.headers {
-            let header_name = http::HeaderName::from_bytes(key.as_bytes()).unwrap();
-            let header_value = http::HeaderValue::from_str(value).unwrap();
-
-            header_map.append(header_name, header_value);
-        }
-
-        header_map
-    }
-
-    pub fn headers_vec(&self) -> &Vec<(String, String)> {
-        self.headers.as_ref()
-    }
-
-    pub fn query_params(&self) -> Vec<(String, String)> {
-        form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
-            .into_owned()
-            .collect()
-    }
-
-    pub fn query_param_length(&self) -> usize {
-        form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes()).count()
-    }
-
-    pub fn body(&self) -> &HttpMockBytes {
-        &self.body
-    }
-
-    pub fn body_string(&self) -> String {
-        self.body.to_string()
-    }
-
-    pub fn body_ref(&self) -> &[u8] {
-        self.body.as_ref()
-    }
-
-    // Move all body functions to HttpMockBytes
-    pub fn body_vec(&self) -> Vec<u8> {
-        self.body.to_vec()
-    }
-
-    pub fn body_bytes(&self) -> bytes::Bytes {
-        self.body.to_bytes()
-    }
-
-    pub fn version(&self) -> http::Version {
-        match self.version.as_ref() {
-            "HTTP/0.9" => http::Version::HTTP_09,
-            "HTTP/1.0" => http::Version::HTTP_10,
-            "HTTP/1.1" => http::Version::HTTP_11,
-            "HTTP/2.0" => http::Version::HTTP_2,
-            "HTTP/3.0" => http::Version::HTTP_3,
-            // Attention: This scenario is highly unlikely, so we panic here for the users
-            // convenience (user does not need to deal with errors for this reason alone).
-            _ => panic!("unknown HTTP version: {:?}", self.version),
-        }
-    }
-
-    pub fn version_ref(&self) -> &str {
-        self.version.as_ref()
-    }
-
-    #[cfg(feature = "cookies")]
-    pub(crate) fn cookies(&self) -> Result<Vec<(String, String)>, Error> {
-        let mut result = Vec::new();
-
-        if let Some(cookie) = self.headers().typed_get::<Cookie>() {
-            for (key, value) in cookie.iter() {
-                result.push((key.to_string(), value.to_string()));
-            }
-        }
-
-        Ok(result)
+            version: format!("{:?}", request.version),
+            body: request.body.clone(),
+        })
     }
 }
 
-fn http_headers_to_vec<T>(req: &http::Request<T>) -> Result<Vec<(String, String)>, Error> {
-    req.headers()
-        .iter()
-        .map(|(name, value)| {
-            // Attempt to convert the HeaderValue to a &str, returning an error if it fails.
-            let value_str = value.to_str().map_err(|e| RequestConversionError(e.to_string()))?;
-            Ok((name.as_str().to_string(), value_str.to_string()))
-        })
-        .collect()
+impl TryFrom<HttpMockRequestWire> for HttpMockRequest {
+    type Error = Error;
+
+    fn try_from(request: HttpMockRequestWire) -> Result<Self, Self::Error> {
+        let scheme = Scheme::from_str(&request.scheme)
+            .map_err(|err| RequestConversionError(format!("invalid scheme: {err}")))?;
+        let uri = Uri::from_str(&request.uri).map_err(|err| RequestConversionError(format!("invalid URI: {err}")))?;
+        let method = HttpMethod::from_bytes(request.method.as_bytes())
+            .map_err(|err| RequestConversionError(format!("invalid method: {err}")))?;
+        let version = parse_http_version(&request.version)?;
+
+        let mut headers = HeaderMap::with_capacity(request.headers.len());
+        for (name, value) in request.headers {
+            let name = http::HeaderName::from_bytes(name.as_bytes())
+                .map_err(|err| RequestConversionError(format!("invalid header name: {err}")))?;
+            let value = HeaderValue::from_str(&value)
+                .map_err(|err| RequestConversionError(format!("invalid header value: {err}")))?;
+            headers.append(name, value);
+        }
+
+        Self::from_parts(scheme, uri, method, headers, version, request.body)
+    }
+}
+
+impl Serialize for HttpMockRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        HttpMockRequestWire::try_from(self)
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for HttpMockRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        HttpMockRequestWire::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+fn parse_http_version(version: &str) -> Result<Version, Error> {
+    match version {
+        "HTTP/0.9" => Ok(Version::HTTP_09),
+        "HTTP/1.0" => Ok(Version::HTTP_10),
+        "HTTP/1.1" => Ok(Version::HTTP_11),
+        "HTTP/2.0" | "HTTP/2" => Ok(Version::HTTP_2),
+        "HTTP/3.0" | "HTTP/3" => Ok(Version::HTTP_3),
+        _ => Err(RequestConversionError(format!("unknown HTTP version: {version}"))),
+    }
+}
+
+fn request_scheme<B>(request: &http::Request<B>) -> Result<Scheme, Error> {
+    if let Some(scheme) = request.uri().scheme() {
+        return Ok(scheme.clone());
+    }
+
+    let metadata = request
+        .extensions()
+        .get::<RequestMetadata>()
+        .ok_or_else(|| RequestConversionError("request has no URI scheme or transport metadata".to_string()))?;
+
+    Ok(metadata.scheme.clone())
+}
+
+impl<B> TryFrom<http::Request<B>> for HttpMockRequest
+where
+    B: Into<HttpMockBytes>,
+{
+    type Error = Error;
+
+    fn try_from(request: http::Request<B>) -> Result<Self, Self::Error> {
+        let scheme = request_scheme(&request)?;
+        let (parts, body) = request.into_parts();
+
+        Self::from_parts(
+            scheme,
+            parts.uri,
+            parts.method,
+            parts.headers,
+            parts.version,
+            body.into(),
+        )
+    }
 }
 
 impl<B> TryFrom<&http::Request<B>> for HttpMockRequest
 where
-    B: Clone + IntoMockBytes,
+    B: Clone + Into<HttpMockBytes>,
 {
     type Error = Error;
 
-    fn try_from(value: &http::Request<B>) -> Result<Self, Self::Error> {
-        let metadata = value
-            .extensions()
-            .get::<RequestMetadata>()
-            .unwrap_or_else(|| panic!("request metadata was not added to the request"));
-
-        let headers = http_headers_to_vec(value)?;
-
-        // Convert the (cloned) body into Bytes, supporting several common body types.
-        let body_bytes = value.body().clone().into_httpmock_bytes()?;
-        let body = HttpMockBytes(body_bytes);
-
-        Ok(HttpMockRequest::new(
-            metadata.scheme.to_string(),
-            value.uri().to_string(),
-            value.method().to_string(),
-            headers,
-            format!("{:?}", value.version()),
-            body,
-        ))
+    fn try_from(request: &http::Request<B>) -> Result<Self, Self::Error> {
+        Self::from_parts(
+            request_scheme(request)?,
+            request.uri().clone(),
+            request.method().clone(),
+            request.headers().clone(),
+            request.version(),
+            request.body().clone().into(),
+        )
     }
 }
 
-impl<B> From<http::Request<B>> for HttpMockRequest
-where
-    B: Clone + IntoMockBytes,
-{
-    fn from(req: http::Request<B>) -> Self {
-        // Use by-ref conversion; we still have access to extensions while owning `req`.
-        <HttpMockRequest as TryFrom<&http::Request<B>>>::try_from(&req)
-            .expect("invalid http::Request for HttpMockRequest: missing metadata or invalid headers/body")
+impl From<HttpMockRequest> for http::Request<Bytes> {
+    fn from(req: HttpMockRequest) -> Self {
+        let scheme = req.scheme.clone();
+        let mut request = http::Request::new(req.body.into());
+        *request.method_mut() = req.method;
+        *request.uri_mut() = req.uri;
+        *request.version_mut() = req.version;
+        *request.headers_mut() = req.headers;
+        request.extensions_mut().insert(RequestMetadata::new(scheme));
+        request
     }
 }
 
-impl From<&HttpMockRequest> for http::Request<bytes::Bytes> {
+impl From<&HttpMockRequest> for http::Request<Bytes> {
     fn from(req: &HttpMockRequest) -> Self {
-        let mut builder = http::Request::builder()
-            .method(req.method())
-            .uri(req.uri())
-            .version(req.version());
-
-        for (k, v) in req.headers() {
-            builder = builder.header(k.map_or(String::new(), |v| v.to_string()), v)
-        }
-
-        builder
-            .body(req.body().to_bytes())
-            .expect("failed to convert HttpMockRequest into http::Request<Bytes>")
+        req.clone().into()
     }
 }
 
-impl From<&HttpMockRequest> for http::Request<String> {
-    fn from(req: &HttpMockRequest) -> Self {
-        let mut builder = http::Request::builder()
-            .method(req.method())
-            .uri(req.uri())
-            .version(req.version());
+#[cfg(test)]
+mod http_message_tests {
+    use super::*;
 
-        for (k, v) in req.headers() {
-            builder = builder.header(k.map_or(String::new(), |v| v.to_string()), v)
-        }
+    #[test]
+    fn request_keeps_typed_http_parts() {
+        let mut request = http::Request::builder()
+            .method(http::Method::PATCH)
+            .uri("https://[::1]:8443/search?q=rust")
+            .version(http::Version::HTTP_2)
+            .body(Bytes::from_static(b"body"))
+            .unwrap();
+        request
+            .headers_mut()
+            .append(http::header::ACCEPT, HeaderValue::from_static("text/plain"));
+        request
+            .headers_mut()
+            .append(http::header::ACCEPT, HeaderValue::from_static("application/json"));
+        request
+            .headers_mut()
+            .insert("x-binary", HeaderValue::from_bytes(&[0x80]).unwrap());
 
-        let body = String::from_utf8(req.body_vec()).expect("request body is not valid UTF-8");
-        builder
-            .body(body)
-            .expect("failed to convert HttpMockRequest into http::Request<String>")
+        let request = HttpMockRequest::try_from(request).unwrap();
+
+        assert_eq!(request.scheme(), &Scheme::HTTPS);
+        assert_eq!(
+            request.uri(),
+            &"https://[::1]:8443/search?q=rust".parse::<Uri>().unwrap()
+        );
+        assert_eq!(request.method(), http::Method::PATCH);
+        assert_eq!(request.version(), Version::HTTP_2);
+        assert_eq!(request.authority().map(Authority::as_str), Some("[::1]:8443"));
+        assert_eq!(request.host(), Some("[::1]"));
+        assert_eq!(request.port(), 8443);
+        assert_eq!(request.headers().get_all(http::header::ACCEPT).iter().count(), 2);
+        assert_eq!(request.headers()["x-binary"].as_bytes(), &[0x80]);
+        assert_eq!(request.body().as_ref(), b"body");
+        assert_eq!(
+            request
+                .query_params()
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect::<Vec<_>>(),
+            vec![("q".to_string(), "rust".to_string())]
+        );
+    }
+
+    #[test]
+    fn request_uses_ipv6_host_header_for_origin_form_uri() {
+        let mut request = http::Request::builder()
+            .uri("/resource")
+            .header(http::header::HOST, "[::1]:8080")
+            .body(Bytes::new())
+            .unwrap();
+        request.extensions_mut().insert(RequestMetadata::new(Scheme::HTTP));
+
+        let request = HttpMockRequest::try_from(request).unwrap();
+
+        assert_eq!(request.authority().map(Authority::as_str), Some("[::1]:8080"));
+        assert_eq!(request.host(), Some("[::1]"));
+        assert_eq!(request.port(), 8080);
+
+        let mut request = http::Request::builder()
+            .uri("/resource")
+            .header(http::header::HOST, "[::1]")
+            .body(Bytes::new())
+            .unwrap();
+        request.extensions_mut().insert(RequestMetadata::new(Scheme::HTTPS));
+
+        let request = HttpMockRequest::try_from(request).unwrap();
+
+        assert_eq!(request.host(), Some("[::1]"));
+        assert_eq!(request.port(), 443);
+    }
+
+    #[test]
+    fn request_rejects_invalid_host_authority() {
+        let mut request = http::Request::builder()
+            .uri("/resource")
+            .header(http::header::HOST, "not an authority")
+            .body(Bytes::new())
+            .unwrap();
+        request.extensions_mut().insert(RequestMetadata::new(Scheme::HTTP));
+
+        assert!(HttpMockRequest::try_from(request).is_err());
+    }
+
+    #[test]
+    fn request_wire_format_matches_existing_schema() {
+        let fixture = serde_json::json!({
+            "scheme": "https",
+            "uri": "https://example.com/resource",
+            "method": "POST",
+            "headers": [["x-test", "one"], ["x-test", "two"]],
+            "version": "HTTP/1.1",
+            "body": [98, 111, 100, 121]
+        });
+
+        let request: HttpMockRequest = serde_json::from_value(fixture.clone()).unwrap();
+
+        assert_eq!(request.headers().get_all("x-test").iter().count(), 2);
+        assert_eq!(serde_json::to_value(request).unwrap(), fixture);
+    }
+
+    #[test]
+    fn request_wire_format_rejects_conflicting_schemes() {
+        let fixture = serde_json::json!({
+            "scheme": "http",
+            "uri": "https://example.com/resource",
+            "method": "GET",
+            "headers": [],
+            "version": "HTTP/1.1",
+            "body": []
+        });
+
+        assert!(serde_json::from_value::<HttpMockRequest>(fixture).is_err());
+    }
+
+    #[test]
+    fn request_wire_format_rejects_non_utf8_headers() {
+        let mut request = http::Request::builder()
+            .uri("http://example.com/")
+            .body(Bytes::new())
+            .unwrap();
+        request
+            .headers_mut()
+            .insert("x-binary", HeaderValue::from_bytes(&[0x80]).unwrap());
+        let request = HttpMockRequest::try_from(request).unwrap();
+
+        assert!(serde_json::to_string(&request).is_err());
+    }
+
+    #[test]
+    fn typed_message_conversions_preserve_parts() {
+        let request = http::Request::builder()
+            .method(http::Method::PUT)
+            .uri("http://example.com/resource")
+            .header("x-test", "value")
+            .body(HttpMockBytes::from(Bytes::from_static(b"request")))
+            .unwrap();
+        let request = HttpMockRequest::try_from(request).unwrap();
+        let request: http::Request<Bytes> = request.into();
+
+        assert_eq!(request.method(), http::Method::PUT);
+        assert_eq!(request.headers()["x-test"], "value");
+        assert_eq!(request.body(), &Bytes::from_static(b"request"));
+
+        let mut response = http::Response::builder()
+            .status(http::StatusCode::CREATED)
+            .body(HttpMockBytes::from(Bytes::from_static(b"response")))
+            .unwrap();
+        response
+            .headers_mut()
+            .insert("x-binary", HeaderValue::from_bytes(&[0x80]).unwrap());
+        let response: HttpMockResponse = response.into();
+        let response: http::Response<Bytes> = response.into();
+
+        assert_eq!(response.status(), http::StatusCode::CREATED);
+        assert_eq!(response.headers()["x-binary"].as_bytes(), &[0x80]);
+        assert_eq!(response.body(), &Bytes::from_static(b"response"));
     }
 }
 
-impl From<&HttpMockRequest> for http::Request<()> {
-    fn from(req: &HttpMockRequest) -> Self {
-        let mut builder = http::Request::builder()
-            .method(req.method())
-            .uri(req.uri())
-            .version(req.version());
-
-        for (k, v) in req.headers() {
-            builder = builder.header(k.map_or(String::new(), |v| v.to_string()), v)
-        }
-
-        builder
-            .body(())
-            .expect("failed to convert HttpMockRequest into http::Request<()>")
-    }
-}
-
-/// A general abstraction of an HTTP response for all handlers.
-#[derive(Serialize, Deserialize, Clone)]
+/// A complete response returned by a dynamic responder.
+#[derive(Debug, Clone)]
 pub struct HttpMockResponse {
-    pub status: Option<u16>,
-    pub headers: Option<Vec<(String, String)>>,
-    #[serde(default, with = "opt_vector_serde_base64")]
-    pub body: Option<HttpMockBytes>,
+    status: http::StatusCode,
+    headers: HeaderMap,
+    body: HttpMockBytes,
 }
 
 impl HttpMockResponse {
+    /// Creates a response builder with status 200, no headers, and an empty body.
     pub fn builder() -> HttpMockResponseBuilder {
-        HttpMockResponseBuilder::new()
+        HttpMockResponseBuilder::default()
+    }
+
+    /// Returns the response status.
+    pub fn status(&self) -> http::StatusCode {
+        self.status
+    }
+
+    /// Returns the response headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Returns the response body.
+    pub fn body(&self) -> &HttpMockBytes {
+        &self.body
     }
 }
 
-/// Converts an `HttpMockResponse` into a real `http::Response<Bytes>`.
-impl TryFrom<HttpMockResponse> for http::Response<bytes::Bytes> {
-    type Error = Error;
-
-    fn try_from(res: HttpMockResponse) -> Result<Self, Self::Error> {
-        (&res).try_into() // reuse the by-ref impl
-    }
-}
-
-impl TryFrom<&HttpMockResponse> for http::Response<bytes::Bytes> {
-    type Error = Error;
-
-    fn try_from(res: &HttpMockResponse) -> Result<Self, Self::Error> {
-        let raw_status = res
-            .status
-            .ok_or_else(|| Error::ResponseConversionError("missing status".into()))?;
-
-        let status = http::StatusCode::from_u16(raw_status)
-            .map_err(|_| Error::ResponseConversionError(format!("invalid status: {}", raw_status)))?;
-
-        let mut builder = http::Response::builder().status(status);
-
-        if let Some(headers) = &res.headers {
-            for (name, value) in headers {
-                let header_name = http::header::HeaderName::try_from(name.clone())
-                    .map_err(|_| Error::ResponseConversionError(format!("invalid header name: {}", name)))?;
-
-                let header_value = http::header::HeaderValue::try_from(value.clone()).map_err(|_| {
-                    Error::ResponseConversionError(format!("invalid header value for '{}': {}", name, value))
-                })?;
-
-                builder = builder.header(header_name, header_value);
-            }
-        }
-
-        let body = res.body.as_ref().map_or(bytes::Bytes::new(), |b| b.0.clone());
-
-        builder
-            .body(body)
-            .map_err(|e| Error::ResponseConversionError(format!("http build error: {}", e)))
-    }
-}
-
-/// Normalizes various response body types into `bytes::Bytes`.
-/// Used by the blanket implementation `TryFrom<http::Response<B>> for HttpMockResponse`.
-/// Implementations prefer zero-copy where possible (e.g., `bytes::Bytes` clones the Arc).
-/// Returns `Result` to allow fallible conversions if needed in the future.
-pub trait IntoMockBytes {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error>;
-}
-
-impl IntoMockBytes for bytes::Bytes {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        // Zero-copy-ish: Bytes is ref-counted; this just clones the handle.
-        Ok(self)
-    }
-}
-
-impl IntoMockBytes for Vec<u8> {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(bytes::Bytes::from(self))
-    }
-}
-
-impl IntoMockBytes for String {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(bytes::Bytes::from(self.into_bytes()))
-    }
-}
-
-impl IntoMockBytes for &'static str {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(bytes::Bytes::from(self))
-    }
-}
-
-impl IntoMockBytes for Box<[u8]> {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(bytes::Bytes::from(self))
-    }
-}
-
-impl IntoMockBytes for std::borrow::Cow<'_, [u8]> {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(match self {
-            std::borrow::Cow::Borrowed(b) => bytes::Bytes::copy_from_slice(b),
-            std::borrow::Cow::Owned(v) => bytes::Bytes::from(v),
-        })
-    }
-}
-
-impl IntoMockBytes for std::borrow::Cow<'_, str> {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(match self {
-            std::borrow::Cow::Borrowed(s) => bytes::Bytes::copy_from_slice(s.as_bytes()),
-            std::borrow::Cow::Owned(s) => bytes::Bytes::from(s.into_bytes()),
-        })
-    }
-}
-
-// Support empty bodies like `http::Response::builder().body(())` used in tests
-impl IntoMockBytes for () {
-    fn into_httpmock_bytes(self) -> Result<bytes::Bytes, Error> {
-        Ok(bytes::Bytes::new())
-    }
-}
-
-impl<B> TryFrom<&http::Response<B>> for HttpMockResponse
-where
-    B: Clone + IntoMockBytes, // Clone only if you need to read body/headers without moving
-{
-    type Error = Error;
-
-    fn try_from(resp: &http::Response<B>) -> Result<Self, Self::Error> {
-        // headers -> Vec<(String, String)> (UTF-8 strict)
-        let mut headers = Vec::with_capacity(resp.headers().len());
-        for (name, value) in resp.headers() {
-            let name = name.as_str().to_string();
-            let val = value
-                .to_str()
-                .map_err(|_| Error::ResponseConversionError(format!("non-utf8 header value for '{}'", name)))?;
-            headers.push((name, val.to_string()));
-        }
-
-        // Body: need a `B` value. Since we only have `&Response<B>`, either:
-        //  - require `B: Clone` and clone it, or
-        //  - restrict this impl to specific `B` you can borrow from (e.g., Bytes)
-        let body_bytes = resp.body().clone().into_httpmock_bytes()?;
-
-        Ok(HttpMockResponse {
-            status: Some(resp.status().as_u16()),
-            headers: Some(headers),
-            body: Some(HttpMockBytes(body_bytes)),
-        })
+impl From<HttpMockResponse> for http::Response<Bytes> {
+    fn from(response: HttpMockResponse) -> Self {
+        let mut result = http::Response::new(response.body.into());
+        *result.status_mut() = response.status;
+        *result.headers_mut() = response.headers;
+        result
     }
 }
 
 impl<B> From<http::Response<B>> for HttpMockResponse
 where
-    B: Clone + IntoMockBytes,
+    B: Into<HttpMockBytes>,
 {
-    fn from(resp: http::Response<B>) -> Self {
-        // Avoid recursive TryFrom<http::Response<B>> derived from this From impl.
-        // Convert by reference using the blanket &Response<B> implementation.
-        <HttpMockResponse as TryFrom<&http::Response<B>>>::try_from(&resp)
-            .expect("invalid http::Response for HttpMockResponse")
+    fn from(response: http::Response<B>) -> Self {
+        let (parts, body) = response.into_parts();
+        Self {
+            status: parts.status,
+            headers: parts.headers,
+            body: body.into(),
+        }
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct HttpMockResponseBuilder {
-    status: Option<u16>,
-    headers: Vec<(String, String)>,
-    body: Option<HttpMockBytes>,
+    status: http::StatusCode,
+    headers: HeaderMap,
+    body: HttpMockBytes,
+}
+
+impl Default for HttpMockResponseBuilder {
+    fn default() -> Self {
+        Self {
+            status: http::StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: HttpMockBytes::from(Bytes::new()),
+        }
+    }
 }
 
 impl HttpMockResponseBuilder {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set an HTTP status (e.g., 200, 404).
-    pub fn status(mut self, status: u16) -> Self {
-        self.status = Some(status);
+    /// Sets the HTTP status.
+    pub fn status(mut self, status: http::StatusCode) -> Self {
+        self.status = status;
         self
     }
 
-    /// Add a single header (appends; duplicates are allowed).
-    pub fn header<K, V>(mut self, key: K, val: V) -> Self
-    where
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.headers.push((key.into(), val.into()));
+    /// Appends a header. Existing values with the same name are preserved.
+    pub fn header(mut self, name: http::HeaderName, value: HeaderValue) -> Self {
+        self.headers.append(name, value);
         self
     }
 
-    /// Replace all headers at once.
-    pub fn headers<I, K, V>(mut self, headers: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.headers = headers.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Replaces all response headers.
+    pub fn headers(mut self, headers: HeaderMap) -> Self {
+        self.headers = headers;
         self
     }
 
-    /// Set a body from anything convertible into `HttpMockBytes`.
+    /// Sets the response body.
     pub fn body<B>(mut self, body: B) -> Self
     where
         B: Into<HttpMockBytes>,
     {
-        self.body = Some(body.into());
+        self.body = body.into();
         self
     }
 
-    /// Explicitly clear the body.
-    pub fn no_body(mut self) -> Self {
-        self.body = None;
-        self
-    }
-
-    /// Finalize into `HttpMockResponse`.
+    /// Builds the response.
     pub fn build(self) -> HttpMockResponse {
         HttpMockResponse {
             status: self.status,
-            headers: if self.headers.is_empty() {
-                None
-            } else {
-                Some(self.headers)
-            },
+            headers: self.headers,
             body: self.body,
         }
     }
 }
 
-/// A general abstraction of an HTTP response for all handlers.
+/// A serializable partial response configuration for static mocks.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct MockServerHttpResponse {
     pub status: Option<u16>,
@@ -650,6 +634,29 @@ impl MockServerHttpResponse {
 impl Default for MockServerHttpResponse {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl TryFrom<MockServerHttpResponse> for HttpMockResponse {
+    type Error = Error;
+
+    fn try_from(response: MockServerHttpResponse) -> Result<Self, Self::Error> {
+        let status = http::StatusCode::from_u16(response.status.unwrap_or(http::StatusCode::OK.as_u16()))
+            .map_err(|err| Error::ResponseConversionError(err.to_string()))?;
+
+        let mut headers = HeaderMap::new();
+        for (name, value) in response.headers.unwrap_or_default() {
+            let name = http::HeaderName::from_bytes(name.as_bytes())
+                .map_err(|err| Error::ResponseConversionError(err.to_string()))?;
+            let value = HeaderValue::from_str(&value).map_err(|err| Error::ResponseConversionError(err.to_string()))?;
+            headers.append(name, value);
+        }
+
+        Ok(Self {
+            status,
+            headers,
+            body: response.body.unwrap_or_else(|| HttpMockBytes::from(Bytes::new())),
+        })
     }
 }
 

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -89,7 +89,12 @@ impl HttpClient for HttpMockHttpClient {
             // Prefer scheme from the URI if present; otherwise use RequestMetadata; fallback to http
             let scheme = uri
                 .scheme_str()
-                .or_else(|| req_parts.extensions.get::<RequestMetadata>().map(|m| m.scheme))
+                .or_else(|| {
+                    req_parts
+                        .extensions
+                        .get::<RequestMetadata>()
+                        .map(|metadata| metadata.scheme.as_str())
+                })
                 .unwrap_or("http");
 
             let path_and_query = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -219,6 +219,18 @@ impl From<Vec<u8>> for HttpMockBytes {
     }
 }
 
+impl From<Box<[u8]>> for HttpMockBytes {
+    fn from(value: Box<[u8]>) -> Self {
+        Self(Bytes::from(value))
+    }
+}
+
+impl From<()> for HttpMockBytes {
+    fn from(_: ()) -> Self {
+        Self(Bytes::new())
+    }
+}
+
 impl From<&[u8]> for HttpMockBytes {
     fn from(value: &[u8]) -> Self {
         Self(Bytes::copy_from_slice(value))

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -6,11 +6,14 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(feature = "proxy")]
+use http::uri::Scheme;
 use http::{HeaderValue, StatusCode, Uri};
 use hyper::{Method, Request, Response, body::Bytes};
 use path_tree::{Path, PathTree};
 use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
+#[cfg(feature = "record")]
 use tokio::time::Instant;
 
 #[cfg(feature = "record")]
@@ -28,7 +31,7 @@ use crate::{
         },
         runtime,
     },
-    prelude::{HttpMockRequest, HttpMockResponse},
+    prelude::HttpMockRequest,
     server::{
         handler::Error::{
             InvalidHeader, ParamError, ParamFormatError, RequestBodyDeserializeError, RequestConversionError,
@@ -384,6 +387,9 @@ where
         #[cfg(not(feature = "proxy"))]
         let (res, is_proxied) = (self.serve_mock(&internal_request).await?, false);
 
+        #[cfg(not(feature = "record"))]
+        let _ = is_proxied;
+
         #[cfg(feature = "record")]
         self.state.record(is_proxied, start.elapsed(), internal_request, &res)?;
 
@@ -406,10 +412,7 @@ where
 
         // Record the upstream scheme (http/https) so the HttpClient can reconstruct
         // an absolute target URI after converting to origin-form.
-        let upstream_scheme: &'static str = match to_base_uri.scheme_str() {
-            Some("https") => "https",
-            _ => "http",
-        };
+        let upstream_scheme = to_base_uri.scheme().cloned().unwrap_or(Scheme::HTTP);
         req_parts
             .extensions
             .insert(crate::server::RequestMetadata::new(upstream_scheme));
@@ -471,18 +474,13 @@ where
             runtime::sleep(std::time::Duration::from_millis(duration)).await;
         }
 
-        // Resolve dynamic vs. static response into HttpMockResponse
-        let resp_def: HttpMockResponse = definition
-            .respond_with
-            .map(|f| f(req))
-            .unwrap_or_else(|| HttpMockResponse {
-                status: definition.status.or(Some(StatusCode::OK.as_u16())),
-                headers: definition.headers,
-                body: definition.body,
-            });
+        let responder = definition.respond_with.clone();
+        let response = match responder {
+            Some(responder) => responder(req),
+            None => definition.try_into().map_err(ResponseDataConversionError)?,
+        };
 
-        // Convert via your TryFrom<HttpMockResponse> impl
-        let http_resp: http::Response<bytes::Bytes> = resp_def.try_into().map_err(ResponseDataConversionError)?;
+        let http_resp: http::Response<bytes::Bytes> = response.into();
 
         Ok(http_resp)
     }

--- a/src/server/matchers/readers.rs
+++ b/src/server/matchers/readers.rs
@@ -556,7 +556,7 @@ pub mod request_value {
 
     #[inline]
     pub fn scheme(req: &HttpMockRequest) -> Option<String> {
-        Some(req.scheme())
+        Some(req.scheme().to_string())
     }
 
     #[inline]
@@ -566,7 +566,7 @@ pub mod request_value {
 
     #[inline]
     pub fn host(req: &HttpMockRequest) -> Option<String> {
-        req.host().map(|h| h.to_string())
+        req.host().map(str::to_owned)
     }
 
     #[inline]
@@ -583,8 +583,7 @@ pub mod request_value {
     pub fn query_params(req: &HttpMockRequest) -> Option<Vec<(String, Option<String>)>> {
         Some(
             req.query_params()
-                .iter()
-                .map(|(k, v)| (k.into(), Some(v.into())))
+                .map(|(k, v)| (k.into_owned(), Some(v.into_owned())))
                 .collect(),
         )
     }
@@ -592,9 +591,14 @@ pub mod request_value {
     #[inline]
     pub fn headers(req: &HttpMockRequest) -> Option<Vec<(String, Option<String>)>> {
         Some(
-            req.headers_vec()
+            req.headers()
                 .iter()
-                .map(|(k, v)| (k.into(), Some(v.into())))
+                .map(|(k, v)| {
+                    (
+                        k.as_str().to_string(),
+                        v.to_str().ok().map(std::string::ToString::to_string),
+                    )
+                })
                 .collect(),
         )
     }
@@ -602,13 +606,7 @@ pub mod request_value {
     #[cfg(feature = "cookies")]
     #[inline]
     pub fn cookies(req: &HttpMockRequest) -> Option<Vec<(String, Option<String>)>> {
-        Some(
-            req.cookies()
-                .expect("cannot parse cookies")
-                .iter()
-                .map(|(k, v)| (k.into(), Some(v.into())))
-                .collect(),
-        )
+        Some(req.cookies().iter().map(|(k, v)| (k.into(), Some(v.into()))).collect())
     }
 
     #[inline]
@@ -618,7 +616,7 @@ pub mod request_value {
 
     #[inline]
     pub fn json_body(req: &HttpMockRequest) -> Option<serde_json::Value> {
-        let body = req.body_ref();
+        let body = req.body().as_ref();
         match serde_json::from_slice(body) {
             Err(e) => {
                 tracing::trace!("Cannot parse json value: {}", e);
@@ -630,7 +628,7 @@ pub mod request_value {
 
     pub fn form_urlencoded_body(req: &HttpMockRequest) -> Option<Vec<(String, Option<String>)>> {
         Some(
-            form_urlencoded::parse(req.body_ref())
+            form_urlencoded::parse(req.body().as_ref())
                 .into_owned()
                 .map(|(k, v)| (k, Some(v)))
                 .collect(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,14 +23,13 @@ pub type HttpMockServer = MockServer<HttpMockHandler<HttpMockStateManager>>;
 /// Per-request metadata propagated through Hyper services.
 #[derive(Clone)]
 pub struct RequestMetadata {
-    /// The scheme ("http" or "https") associated with this request, used by the
-    /// upstream client to reconstruct the absolute target when needed.
-    pub scheme: &'static str,
+    /// The transport scheme used to reconstruct an absolute request target.
+    pub scheme: http::uri::Scheme,
 }
 
 impl RequestMetadata {
-    /// Create new RequestMetadata for a request with the given scheme.
-    pub fn new(scheme: &'static str) -> Self {
+    /// Creates request metadata for a transport scheme.
+    pub fn new(scheme: http::uri::Scheme) -> Self {
         Self { scheme }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -301,7 +301,7 @@ where
         }
 
         tracing::trace!("TCP connection is not TLS encrypted");
-        serve_connection(self.clone(), tcp_stream, "http").await
+        serve_connection(self.clone(), tcp_stream, http::uri::Scheme::HTTP).await
     }
 }
 
@@ -341,7 +341,7 @@ where
         .await
         .map_err(|e| Error::TlsError(format!("TLS accept failed: {:?}", e)))?;
 
-    serve_connection(server, tls_stream, "https").await
+    serve_connection(server, tls_stream, http::uri::Scheme::HTTPS).await
 }
 
 // `serve_connection` cannot be a plain `async fn` (nor return an implicit/explicit
@@ -355,7 +355,7 @@ where
 fn serve_connection<H, S>(
     server: Arc<MockServer<H>>,
     stream: S,
-    scheme: &'static str,
+    scheme: http::uri::Scheme,
 ) -> BoxFuture<'static, Result<(), Error>>
 where
     H: Handler + Send + Sync + 'static,
@@ -372,10 +372,9 @@ where
             .serve_connection_with_upgrades(
                 TokioIo::new(stream),
                 service_fn(|mut req| {
-                    // We pass authority None here since we don't know it for non-CONNECT requests
-                    // yet. We only know it when the full request has been buffered in `service()`.
-                    // Here, we only the scheme is known from the connection type.
-                    req.extensions_mut().insert(RequestMetadata::new(scheme));
+                    // URI normalization combines this transport scheme with the buffered
+                    // request's authority.
+                    req.extensions_mut().insert(RequestMetadata::new(scheme.clone()));
                     server.clone().service(req)
                 }),
             )
@@ -421,8 +420,8 @@ fn to_absolute_form_uri(req: &mut Request<Bytes>) -> Result<(), Error> {
     let default_scheme = req
         .extensions()
         .get::<RequestMetadata>()
-        .map(|m| m.scheme)
-        .unwrap_or("http");
+        .map(|metadata| metadata.scheme.clone())
+        .unwrap_or(http::uri::Scheme::HTTP);
 
     // If already absolute-form (scheme + authority), leave as-is
     let uri = req.uri().clone();

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -18,9 +18,8 @@ use crate::{
 };
 use crate::{
     common::data::{
-        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
-        ForwardingRuleConfig, Mismatch, MockDefinition, MockServerHttpResponse, ProxyRuleConfig,
-        RecordingRuleConfig, RequestRequirements,
+        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch, ForwardingRuleConfig,
+        Mismatch, MockDefinition, MockServerHttpResponse, ProxyRuleConfig, RecordingRuleConfig, RequestRequirements,
     },
     prelude::HttpMockRequest,
     server::{
@@ -111,14 +110,8 @@ pub(crate) trait StateManager {
     #[cfg(feature = "record")]
     fn load_mocks_from_recording(&self, recording_file_content: &str) -> Result<Vec<usize>, Error>;
 
-    fn find_forward_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveForwardingRule>, Error>;
-    fn find_proxy_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveProxyRule>, Error>;
+    fn find_forward_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveForwardingRule>, Error>;
+    fn find_proxy_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveProxyRule>, Error>;
     fn record<
         IntoResponse: TryInto<MockServerHttpResponse, Error = impl std::fmt::Display + std::fmt::Debug + 'static>,
     >(
@@ -188,9 +181,10 @@ impl StateManager for HttpMockStateManager {
         let mut state = self.state.lock().unwrap();
 
         if let Some(m) = state.mocks.get(&id)
-            && m.is_static {
-                return Err(StaticMockError);
-            }
+            && m.is_static
+        {
+            return Err(StaticMockError);
+        }
 
         tracing::debug!("Deleting mock with id={}", id);
 
@@ -229,8 +223,7 @@ impl StateManager for HttpMockStateManager {
             .filter(|req| !request_matches(&state.matchers, req, requirements))
             .collect();
 
-        let request_distances =
-            get_distances(&non_matching_requests, &state.matchers, requirements);
+        let request_distances = get_distances(&non_matching_requests, &state.matchers, requirements);
         let best_matches = get_min_distance_requests(&request_distances);
 
         let closes_match_request_idx = match best_matches.first() {
@@ -266,11 +259,7 @@ impl StateManager for HttpMockStateManager {
         let found_mock_id = result.map(|mock| mock.id);
 
         if let Some(found_id) = found_mock_id {
-            tracing::debug!(
-                "Matched mock with id={} to the following request: {:#?}",
-                found_id,
-                req
-            );
+            tracing::debug!("Matched mock with id={} to the following request: {:#?}", found_id, req);
 
             let mock = state.mocks.get_mut(&found_id).unwrap();
             mock.call_counter += 1;
@@ -278,10 +267,7 @@ impl StateManager for HttpMockStateManager {
             return Ok(Some(mock.definition.response.clone()));
         }
 
-        tracing::debug!(
-            "Could not match any mock to the following request: {:#?}",
-            req
-        );
+        tracing::debug!("Could not match any mock to the following request: {:#?}", req);
 
         Ok(None)
     }
@@ -410,8 +396,7 @@ impl StateManager for HttpMockStateManager {
 
         if let Some(rec) = state.recordings.get(&id) {
             return Ok(Some(
-                serialize_mock_defs_to_yaml(&rec.mocks)
-                    .map_err(|err| DataConversionError(err.to_string()))?,
+                serialize_mock_defs_to_yaml(&rec.mocks).map_err(|err| DataConversionError(err.to_string()))?,
             ));
         }
 
@@ -443,10 +428,7 @@ impl StateManager for HttpMockStateManager {
         Ok(mock_ids)
     }
 
-    fn find_forward_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveForwardingRule>, Error> {
+    fn find_forward_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveForwardingRule>, Error> {
         let state = self.state.lock().unwrap();
 
         let result = state
@@ -458,10 +440,7 @@ impl StateManager for HttpMockStateManager {
         Ok(result)
     }
 
-    fn find_proxy_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveProxyRule>, Error> {
+    fn find_proxy_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveProxyRule>, Error> {
         let state = self.state.lock().unwrap();
 
         let result = state
@@ -495,14 +474,11 @@ impl StateManager for HttpMockStateManager {
             return Ok(());
         }
 
-        let res = res
-            .try_into()
-            .map_err(|err| DataConversionError(err.to_string()))?;
+        let res = res.try_into().map_err(|err| DataConversionError(err.to_string()))?;
 
         for id in recording_ids {
             let rec = state.recordings.get_mut(&id).unwrap();
-            let definition =
-                build_mock_definition(is_proxied, time_taken, &req, &res, &rec.config)?;
+            let definition = build_mock_definition(is_proxied, time_taken, &req, &res, &rec.config)?;
             rec.mocks.push(definition);
         }
 
@@ -524,12 +500,11 @@ fn build_mock_definition(
         let header_name_lowercase = header_name.to_lowercase();
         for (key, value) in request.headers() {
             if let Some(key) = key
-                && header_name_lowercase == key.to_string().to_lowercase() {
-                    let value = value
-                        .to_str()
-                        .map_err(|err| DataConversionError(err.to_string()))?;
-                    headers.push((header_name.to_string(), value.to_string()))
-                }
+                && header_name_lowercase == key.to_string().to_lowercase()
+            {
+                let value = value.to_str().map_err(|err| DataConversionError(err.to_string()))?;
+                headers.push((header_name.to_string(), value.to_string()))
+            }
         }
     }
 
@@ -570,11 +545,7 @@ fn build_mock_definition(
         },
         path: Some(request.uri().path().to_string()),
         method: Some(request.method().to_string()),
-        header: if !headers.is_empty() {
-            Some(headers)
-        } else {
-            None
-        },
+        header: if !headers.is_empty() { Some(headers) } else { None },
         body: if request.body().is_empty() {
             None
         } else {
@@ -604,9 +575,10 @@ fn validate_request_requirements(req: &RequestRequirements) -> Result<(), Error>
 
     if let Some(_body) = &req.body
         && let Some(method) = &req.method
-            && NON_BODY_METHODS.contains(&method.as_str()) {
-                return Err(BodyMethodInvalid);
-            }
+        && NON_BODY_METHODS.contains(&method.as_str())
+    {
+        return Err(BodyMethodInvalid);
+    }
     Ok(())
 }
 
@@ -616,9 +588,7 @@ fn request_matches(
     request_requirements: &RequestRequirements,
 ) -> bool {
     tracing::trace!("Matching incoming HTTP request");
-    matchers
-        .iter()
-        .all(|x| x.matches(req, request_requirements))
+    matchers.iter().all(|x| x.matches(req, request_requirements))
 }
 
 fn get_distances(
@@ -667,10 +637,7 @@ fn get_request_mismatches(
     mock_rr: &RequestRequirements,
     matchers: &Vec<Box<dyn Matcher + Sync + Send>>,
 ) -> Vec<Mismatch> {
-    matchers
-        .iter()
-        .flat_map(|mat| mat.mismatches(req, mock_rr))
-        .collect()
+    matchers.iter().flat_map(|mat| mat.mismatches(req, mock_rr)).collect()
 }
 
 #[cfg(test)]
@@ -716,9 +683,6 @@ mod tests {
     #[test]
     fn default_history_limit_is_preserved() {
         let manager = HttpMockStateManager::default();
-        assert_eq!(
-            manager.state.lock().unwrap().history_limit,
-            DEFAULT_HISTORY_LIMIT
-        );
+        assert_eq!(manager.state.lock().unwrap().history_limit, DEFAULT_HISTORY_LIMIT);
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -499,9 +499,7 @@ fn build_mock_definition(
     for header_name in &config.record_headers {
         let header_name_lowercase = header_name.to_lowercase();
         for (key, value) in request.headers() {
-            if let Some(key) = key
-                && header_name_lowercase == key.to_string().to_lowercase()
-            {
+            if header_name_lowercase == key.as_str().to_lowercase() {
                 let value = value.to_str().map_err(|err| DataConversionError(err.to_string()))?;
                 headers.push((header_name.to_string(), value.to_string()))
             }
@@ -551,10 +549,12 @@ fn build_mock_definition(
         } else {
             Some(request.body().clone())
         },
-        query_param: if request.query_param_length() == 0 {
-            None
-        } else {
-            Some(request.query_params())
+        query_param: {
+            let query_params: Vec<_> = request
+                .query_params()
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect();
+            (!query_params.is_empty()).then_some(query_params)
         },
         ..Default::default()
     };
@@ -643,17 +643,14 @@ fn get_request_mismatches(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::util::HttpMockBytes;
 
     fn dummy_request() -> HttpMockRequest {
-        HttpMockRequest::new(
-            "http".to_string(),
-            "/test".to_string(),
-            "GET".to_string(),
-            Vec::new(),
-            "HTTP/1.1".to_string(),
-            HttpMockBytes::from(bytes::Bytes::new()),
-        )
+        http::Request::builder()
+            .uri("http://localhost/test")
+            .body(bytes::Bytes::new())
+            .unwrap()
+            .try_into()
+            .unwrap()
     }
 
     #[test]

--- a/tests/examples/custom_request_matcher_tests.rs
+++ b/tests/examples/custom_request_matcher_tests.rs
@@ -76,26 +76,27 @@ fn is_false_matcher_called_once_per_request() {
 
 #[test]
 fn dynamic_responder_test() {
-    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use http::StatusCode;
     use httpmock::prelude::*;
     use reqwest::blocking::Client;
 
     // Arrange
     let server = MockServer::start();
 
-    // This is our counter that will determine the response later.
-    // It needs to be protected by a mutex the custom respond method
-    // is called from the HTTP server thread.
-    let call_count = Mutex::new(0);
+    let call_count = AtomicUsize::new(0);
 
     let mock = server.mock(|when, then| {
         when.method("GET").is_true(|r| r.uri().path().ends_with("/hello"));
         then.respond_with(move |_req: &HttpMockRequest| {
-            let mut count = call_count.lock().unwrap();
-            *count += 1;
+            let status = match call_count.fetch_add(1, Ordering::Relaxed) {
+                0 => StatusCode::CREATED,
+                1 => StatusCode::ACCEPTED,
+                _ => StatusCode::NON_AUTHORITATIVE_INFORMATION,
+            };
 
-            HttpMockResponse::builder().status(200 + *count).build()
+            HttpMockResponse::builder().status(status).build()
         });
     });
 
@@ -132,14 +133,11 @@ fn dynamic_responder_http_crate_test() {
     let mock = server.mock(|when, then| {
         when.method("GET");
         then.respond_with(move |req: &HttpMockRequest| {
-            // Convert the HttpMockRequest to a http creates Request object
-            let req: http::Request<()> = req.into();
+            let req: http::Request<bytes::Bytes> = req.into();
 
             let mut count = call_count.lock().unwrap();
             *count += 1;
 
-            // Return a http crate Response object which will automatically be converted into
-            // a HttpMockResponse internally
             http::Response::builder()
                 .status(200 + *count)
                 .body(req.uri().path().to_string())


### PR DESCRIPTION
## Summary

This is a breaking change.

Requests and dynamic responses now keep their `http` types internally. Request authorities are parsed once, and the public interface exposes borrowed typed values instead of rebuilding them from strings.

This removes redundant request accessors and response conversions. It also fixes the IPv6 authority parsing covered by #208.

This is based on #258.

## Checks

- `cargo test`
- `cargo test --all-features --lib`
- `cargo clippy --all-targets --all-features`
