### PR TITLE
breaking: validate forwarding rules at creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- `MockServer::forward_to` and `MockServer::forward_to_async` now return `Result` and reject invalid forwarding targets when the rule is created.
+
 ## Version 0.8.3
 
 Minimum supported Rust version has been raised to 1.88.

--- a/src/api/adapter/local.rs
+++ b/src/api/adapter/local.rs
@@ -85,7 +85,9 @@ impl MockServerAdapter for LocalMockServerAdapter {
         &self,
         config: ForwardingRuleConfig,
     ) -> Result<ActiveForwardingRule, ServerAdapterError> {
-        Ok(self.state.create_forwarding_rule(config))
+        self.state
+            .create_forwarding_rule(config)
+            .map_err(|err| UpstreamError(err.to_string()))
     }
 
     async fn delete_forwarding_rule(&self, id: usize) -> Result<(), ServerAdapterError> {

--- a/src/api/mock.rs
+++ b/src/api/mock.rs
@@ -104,7 +104,6 @@ impl<'a> Mock<'a> {
     /// ```rust
     /// use httpmock::prelude::*;
     /// use reqwest::get;
-    /// use syn::token;
     ///
     /// let rt = tokio::runtime::Runtime::new().unwrap();
     /// rt.block_on(async {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "remote")]
 pub use adapter::remote::RemoteMockServerAdapter;
-pub use adapter::{MockServerAdapter, local::LocalMockServerAdapter};
+pub use adapter::{MockServerAdapter, ServerAdapterError, local::LocalMockServerAdapter};
 pub use mock::{Mock, MockExt};
 #[cfg(feature = "proxy")]
 pub use proxy::{ForwardingRule, ForwardingRuleBuilder, ProxyRule, ProxyRuleBuilder};

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -25,7 +25,7 @@ use crate::common::http::HttpMockHttpClient;
 use crate::{
     Mock,
     api::{
-        LocalMockServerAdapter, MockServerAdapter,
+        LocalMockServerAdapter, MockServerAdapter, ServerAdapterError,
         spec::{Then, When},
     },
     common::{
@@ -518,6 +518,9 @@ impl MockServer {
     /// # Returns
     /// A `ForwardingRule` object representing the configured forwarding rule.
     ///
+    /// # Errors
+    /// Returns an error when the target is not an absolute HTTP or HTTPS URL, or when the server cannot create the rule.
+    ///
     /// # Example
     /// ```rust
     /// use httpmock::prelude::*;
@@ -540,7 +543,7 @@ impl MockServer {
     ///     rule.filter(|when| {
     ///         when.any_request(); // We want all requests to be forwarded.
     ///     });
-    /// });
+    /// }).unwrap();
     ///
     /// // Now let's send an HTTP request to the mock server. The request will be forwarded
     /// // to the target host, as we configured before.
@@ -561,7 +564,7 @@ impl MockServer {
         &self,
         to_base_url: IntoString,
         rule: ForwardingRuleBuilderFn,
-    ) -> ForwardingRule<'_>
+    ) -> Result<ForwardingRule<'_>, ServerAdapterError>
     where
         ForwardingRuleBuilderFn: FnOnce(ForwardingRuleBuilder),
         IntoString: Into<String>,
@@ -579,6 +582,9 @@ impl MockServer {
     ///
     /// # Returns
     /// A `ForwardingRule` object representing the configured forwarding rule.
+    ///
+    /// # Errors
+    /// Returns an error when the target is not an absolute HTTP or HTTPS URL, or when the server cannot create the rule.
     ///
     /// # Example
     /// ```rust
@@ -604,7 +610,7 @@ impl MockServer {
     ///         rule.filter(|when| {
     ///             when.any_request(); // We want all requests to be forwarded.
     ///         });
-    ///     }).await;
+    ///     }).await.unwrap();
     ///
     ///     // Now let's send an HTTP request to the mock server. The request will be forwarded
     ///     // to the target host, as we configured before.
@@ -625,7 +631,7 @@ impl MockServer {
         &'a self,
         target_base_url: IntoString,
         rule: ForwardingRuleBuilderFn,
-    ) -> ForwardingRule<'a>
+    ) -> Result<ForwardingRule<'a>, ServerAdapterError>
     where
         ForwardingRuleBuilderFn: FnOnce(ForwardingRuleBuilder),
         IntoString: Into<String>,
@@ -647,13 +653,12 @@ impl MockServer {
                 request_requirements: req.take(),
                 request_header: headers.take(),
             })
-            .await
-            .expect("Cannot deserialize mock server response");
+            .await?;
 
-        ForwardingRule {
+        Ok(ForwardingRule {
             id: response.id,
             server: self,
-        }
+        })
     }
 
     /// Configures the mock server to proxy HTTP requests based on specified criteria.
@@ -851,7 +856,7 @@ impl MockServer {
     ///     rule.filter(|when| {
     ///         when.path("/hello"); // Forward all requests with path "/hello".
     ///     });
-    /// });
+    /// }).unwrap();
     ///
     /// // Record the target server's response.
     /// let recording = recording_server.record(|rule| {
@@ -937,7 +942,7 @@ impl MockServer {
     ///         rule.filter(|when| {
     ///             when.path("/hello"); // Forward all requests with path "/hello".
     ///         });
-    ///     }).await;
+    ///     }).await.unwrap();
     ///
     ///     // Record the target server's response.
     ///     let recording = recording_server.record_async(|rule| {
@@ -1039,7 +1044,7 @@ impl MockServer {
     ///     rule.filter(|when| {
     ///         when.path("/hello"); // Forward all requests with path "/hello".
     ///     });
-    /// });
+    /// }).unwrap();
     ///
     /// // Record the target server's response.
     /// let recording = recording_server.record(|rule| {
@@ -1119,7 +1124,7 @@ impl MockServer {
     ///         rule.filter(|when| {
     ///             when.path("/hello"); // Forward all requests with path "/hello".
     ///         });
-    ///     }).await;
+    ///     }).await.unwrap();
     ///
     ///     // Record the target server's response.
     ///     let recording = recording_server.record_async(|rule| {

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -25,7 +25,7 @@ use crate::common::http::HttpMockHttpClient;
 use crate::{
     Mock,
     api::{
-        LocalMockServerAdapter, MockServerAdapter, ServerAdapterError,
+        LocalMockServerAdapter, MockServerAdapter,
         spec::{Then, When},
     },
     common::{
@@ -37,7 +37,10 @@ use crate::{
 };
 #[cfg(feature = "proxy")]
 use crate::{
-    api::proxy::{ForwardingRule, ForwardingRuleBuilder, ProxyRule, ProxyRuleBuilder},
+    api::{
+        ServerAdapterError,
+        proxy::{ForwardingRule, ForwardingRuleBuilder, ProxyRule, ProxyRuleBuilder},
+    },
     common::data::{ForwardingRuleConfig, ProxyRuleConfig},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 
 mod common;
 
-pub use api::{Method, Mock, MockExt, MockServer, Regex, Then, When};
+pub use api::{Method, Mock, MockExt, MockServer, Regex, ServerAdapterError, Then, When};
 pub use common::data::{HttpMockRequest, HttpMockResponse};
 mod api;
 pub mod server;

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -15,12 +15,12 @@ use tokio::time::Instant;
 
 #[cfg(feature = "record")]
 use crate::common::data::RecordingRuleConfig;
-#[cfg(feature = "proxy")]
-use crate::common::data::{ActiveForwardingRule, ActiveProxyRule};
 #[cfg(any(feature = "remote", feature = "proxy"))]
 use crate::common::http::Error as HttpClientError;
 #[cfg(feature = "proxy")]
 use crate::common::http::HttpClient;
+#[cfg(feature = "proxy")]
+use crate::{common::data::ActiveProxyRule, server::state::ForwardingRule};
 use crate::{
     common::{
         data,
@@ -264,7 +264,7 @@ impl Handler {
 
     fn handle_add_forwarding_rule(&self, req: Request<Bytes>) -> Result<Response<Bytes>, Error> {
         let config: ForwardingRuleConfig = parse_json_body(req)?;
-        let active_forwarding_rule = self.state.create_forwarding_rule(config);
+        let active_forwarding_rule = self.state.create_forwarding_rule(config)?;
         response(StatusCode::CREATED, Some(active_forwarding_rule))
     }
 
@@ -371,46 +371,33 @@ impl Handler {
     }
 
     #[cfg(feature = "proxy")]
-    async fn forward(&self, rule: ActiveForwardingRule, req: Request<Bytes>) -> Result<Response<Bytes>, Error> {
-        let to_base_uri: Uri = rule.config.target_base_url.parse().unwrap();
+    async fn forward(&self, rule: ForwardingRule, req: Request<Bytes>) -> Result<Response<Bytes>, Error> {
+        let state::ForwardingRule {
+            active: _,
+            target,
+            request_headers,
+        } = rule;
+        let (target_scheme_name, target_scheme, target_authority) = target.into_parts();
 
         let (mut req_parts, body) = req.into_parts();
 
-        // We need to remove the host header, because it contains the host of this mock server.
+        // The forwarding target replaces the mock server host.
         req_parts.headers.remove(http::header::HOST);
 
         let mut uri_parts = req_parts.uri.into_parts();
-        uri_parts.authority = Some(to_base_uri.authority().unwrap().clone());
-        uri_parts.scheme = to_base_uri.scheme().cloned().or(uri_parts.scheme);
-        req_parts.uri = Uri::from_parts(uri_parts).unwrap();
+        uri_parts.authority = Some(target_authority);
+        uri_parts.scheme = Some(target_scheme);
+        req_parts.uri = Uri::from_parts(uri_parts).map_err(|err| RequestConversionError(err.to_string()))?;
 
-        // Record the upstream scheme (http/https) so the HttpClient can reconstruct
-        // an absolute target URI after converting to origin-form.
-        let upstream_scheme: &'static str = match to_base_uri.scheme_str() {
-            Some("https") => "https",
-            _ => "http",
-        };
+        // The client uses this scheme when reconstructing the absolute upstream URI.
         req_parts
             .extensions
-            .insert(crate::server::RequestMetadata::new(upstream_scheme));
+            .insert(crate::server::RequestMetadata::new(target_scheme_name));
 
-        if !rule.config.request_header.is_empty() {
-            for (key, value) in &rule.config.request_header {
-                let key = http::HeaderName::from_str(key)
-                    .map_err(|err| InvalidHeader(format!("invalid header key: {}", err)))?;
-
-                let value = HeaderValue::from_str(value)
-                    .map_err(|err| InvalidHeader(format!("invalid header value: {}", err)))?;
-
-                req_parts.headers.append(key, value);
-            }
-        }
+        req_parts.headers.extend(request_headers);
 
         let req = Request::from_parts(req_parts, body);
-        // Requests are normalized to absolute-form inside this server for internal uniformity
-        // (matchers/recorders can read scheme/host/port from req.uri()). Before talking to an
-        // upstream origin server we MUST convert to origin-form (path + query only) and provide
-        // the authority via the Host header, as expected by HTTP/1.1 and HTTP/2 origin servers.
+        // Origin servers receive the path and query in the request target and the authority in `Host`.
         let req = to_origin_form(req)?;
         Ok(self.http_client.send(req).await?)
     }

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -387,7 +387,7 @@ impl Handler {
         let mut uri_parts = req_parts.uri.into_parts();
         uri_parts.authority = Some(target_authority);
         uri_parts.scheme = Some(target_scheme);
-        req_parts.uri = Uri::from_parts(uri_parts).map_err(|err| RequestConversionError(err.to_string()))?;
+        req_parts.uri = Uri::from_parts(uri_parts).map_err(|err| RequestConversion(err.to_string()))?;
 
         // The client uses this scheme when reconstructing the absolute upstream URI.
         req_parts
@@ -528,4 +528,29 @@ pub fn to_origin_form(mut req: Request<Bytes>) -> Result<Request<Bytes>, Error> 
     }
 
     Ok(req)
+}
+
+#[cfg(all(test, feature = "proxy"))]
+mod tests {
+    use super::*;
+    use crate::common::http::HttpMockHttpClient;
+
+    #[test]
+    fn valid_forwarding_rule_can_be_added() {
+        let handler = Handler::new(
+            Arc::new(state::Manager::default()),
+            Arc::new(HttpMockHttpClient::new(None)),
+        );
+        let config = ForwardingRuleConfig {
+            target_base_url: "http://example.com".to_string(),
+            ..Default::default()
+        };
+        let request = Request::post("/__httpmock__/forwarding_rules")
+            .body(Bytes::from(serde_json::to_vec(&config).unwrap()))
+            .unwrap();
+
+        let response = handler.handle_add_forwarding_rule(request).unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,11 +1,13 @@
 use std::{
     collections::BTreeMap,
+    str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 #[cfg(feature = "record")]
 use bytes::Bytes;
+use http::{HeaderMap, HeaderName, HeaderValue, Uri, uri::Authority};
 use thiserror::Error;
 
 #[cfg(feature = "record")]
@@ -58,9 +60,66 @@ pub(crate) struct Inner {
     pub mocks: BTreeMap<usize, ActiveMock>,
     pub history: Vec<Arc<HttpMockRequest>>,
     pub matchers: Vec<Box<dyn Matcher + Sync + Send>>,
-    pub forwarding_rules: BTreeMap<usize, ActiveForwardingRule>,
+    pub(crate) forwarding_rules: BTreeMap<usize, ForwardingRule>,
     pub proxy_rules: BTreeMap<usize, ActiveProxyRule>,
     pub recordings: BTreeMap<usize, ActiveRecording>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ForwardingRule {
+    pub active: ActiveForwardingRule,
+    pub target: ForwardTarget,
+    pub request_headers: HeaderMap,
+}
+
+#[derive(Clone)]
+pub(crate) struct ForwardTarget {
+    scheme: ForwardScheme,
+    authority: Authority,
+}
+
+#[derive(Clone, Copy)]
+enum ForwardScheme {
+    Http,
+    Https,
+}
+
+impl TryFrom<&str> for ForwardTarget {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let uri =
+            Uri::from_str(value).map_err(|err| Error::ValidationError(format!("invalid forwarding target: {err}")))?;
+        let parts = uri.into_parts();
+
+        let scheme = match parts.scheme.as_ref().map(|scheme| scheme.as_str()) {
+            Some("http") => ForwardScheme::Http,
+            Some("https") => ForwardScheme::Https,
+            Some(scheme) => {
+                return Err(Error::ValidationError(format!(
+                    "invalid forwarding target scheme '{scheme}': expected http or https"
+                )));
+            }
+            None => return Err(Error::ValidationError("forwarding target has no scheme".to_string())),
+        };
+
+        let authority = parts
+            .authority
+            .ok_or_else(|| Error::ValidationError("forwarding target has no authority".to_string()))?;
+
+        Ok(Self { scheme, authority })
+    }
+}
+
+impl ForwardTarget {
+    pub fn into_parts(self) -> (&'static str, http::uri::Scheme, Authority) {
+        let (name, scheme) = match self.scheme {
+            ForwardScheme::Http => ("http", http::uri::Scheme::HTTP),
+            ForwardScheme::Https => ("https", http::uri::Scheme::HTTPS),
+        };
+
+        (name, scheme, self.authority)
+    }
 }
 
 impl Inner {
@@ -223,25 +282,39 @@ impl Manager {
         Ok(None)
     }
 
-    pub(crate) fn create_forwarding_rule(&self, config: ForwardingRuleConfig) -> ActiveForwardingRule {
+    pub(crate) fn create_forwarding_rule(&self, config: ForwardingRuleConfig) -> Result<ActiveForwardingRule, Error> {
+        let target = ForwardTarget::try_from(config.target_base_url.as_str())?;
+        let mut request_headers = HeaderMap::with_capacity(config.request_header.len());
+        for (name, value) in &config.request_header {
+            let name = HeaderName::from_str(name)
+                .map_err(|err| Error::ValidationError(format!("invalid forwarding header name: {err}")))?;
+            let value = HeaderValue::from_str(value)
+                .map_err(|err| Error::ValidationError(format!("invalid forwarding header value: {err}")))?;
+            request_headers.append(name, value);
+        }
         let mut state = self.state.lock().unwrap();
 
-        let rule = ActiveForwardingRule {
+        let active = ActiveForwardingRule {
             id: state.next_forwarding_rule_id,
             config,
         };
+        let rule = ForwardingRule {
+            active: active.clone(),
+            target,
+            request_headers,
+        };
 
-        state.forwarding_rules.insert(rule.id, rule.clone());
+        state.forwarding_rules.insert(active.id, rule);
 
         state.next_forwarding_rule_id += 1;
 
-        rule
+        Ok(active)
     }
 
     pub(crate) fn delete_forwarding_rule(&self, id: usize) -> Option<ActiveForwardingRule> {
         let mut state = self.state.lock().unwrap();
 
-        let result = state.forwarding_rules.remove(&id);
+        let result = state.forwarding_rules.remove(&id).map(|rule| rule.active);
 
         if result.is_some() {
             tracing::debug!("Deleting proxy rule with id={}", id);
@@ -382,13 +455,13 @@ impl Manager {
     pub(crate) fn find_forward_rule<'a>(
         &'a self,
         req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveForwardingRule>, Error> {
+    ) -> Result<Option<ForwardingRule>, Error> {
         let state = self.state.lock().unwrap();
 
         let result = state
             .forwarding_rules
             .values()
-            .find(|&rule| request_matches(&state.matchers, req, &rule.config.request_requirements))
+            .find(|&rule| request_matches(&state.matchers, req, &rule.active.config.request_requirements))
             .cloned();
 
         Ok(result)

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -452,10 +452,7 @@ impl Manager {
         Ok(mock_ids)
     }
 
-    pub(crate) fn find_forward_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ForwardingRule>, Error> {
+    pub(crate) fn find_forward_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ForwardingRule>, Error> {
         let state = self.state.lock().unwrap();
 
         let result = state
@@ -717,5 +714,35 @@ mod tests {
     fn default_history_limit_is_preserved() {
         let manager = Manager::default();
         assert_eq!(manager.state.lock().unwrap().history_limit, DEFAULT_HISTORY_LIMIT);
+    }
+
+    #[test]
+    fn static_mock_cannot_be_deleted() {
+        let manager = Manager::default();
+        let active_mock = manager
+            .add_mock(
+                MockDefinition::new(RequestRequirements::default(), MockServerHttpResponse::default()),
+                true,
+            )
+            .expect("static mock should be created");
+
+        assert!(matches!(
+            manager.delete_mock(active_mock.id),
+            Err(Error::StaticMockError)
+        ));
+    }
+
+    #[test]
+    fn get_request_with_body_is_rejected() {
+        let requirements = RequestRequirements {
+            method: Some("GET".to_string()),
+            body: Some(HttpMockBytes::from(bytes::Bytes::from_static(b"body"))),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            validate_request_requirements(&requirements),
+            Err(Error::BodyMethodInvalid)
+        ));
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -18,9 +18,8 @@ use crate::{
 };
 use crate::{
     common::data::{
-        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch,
-        ForwardingRuleConfig, Mismatch, MockDefinition, MockServerHttpResponse, ProxyRuleConfig,
-        RecordingRuleConfig, RequestRequirements,
+        ActiveForwardingRule, ActiveMock, ActiveProxyRule, ActiveRecording, ClosestMatch, ForwardingRuleConfig,
+        Mismatch, MockDefinition, MockServerHttpResponse, ProxyRuleConfig, RecordingRuleConfig, RequestRequirements,
     },
     prelude::HttpMockRequest,
     server::{
@@ -111,14 +110,8 @@ pub(crate) trait StateManager {
     #[cfg(feature = "record")]
     fn load_mocks_from_recording(&self, recording_file_content: &str) -> Result<Vec<usize>, Error>;
 
-    fn find_forward_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveForwardingRule>, Error>;
-    fn find_proxy_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveProxyRule>, Error>;
+    fn find_forward_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveForwardingRule>, Error>;
+    fn find_proxy_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveProxyRule>, Error>;
     fn record<
         IntoResponse: TryInto<MockServerHttpResponse, Error = impl std::fmt::Display + std::fmt::Debug + 'static>,
     >(
@@ -188,9 +181,10 @@ impl StateManager for HttpMockStateManager {
         let mut state = self.state.lock().unwrap();
 
         if let Some(m) = state.mocks.get(&id)
-            && m.is_static {
-                return Err(StaticMockError);
-            }
+            && m.is_static
+        {
+            return Err(StaticMockError);
+        }
 
         tracing::debug!("Deleting mock with id={}", id);
 
@@ -229,8 +223,7 @@ impl StateManager for HttpMockStateManager {
             .filter(|req| !request_matches(&state.matchers, req, requirements))
             .collect();
 
-        let request_distances =
-            get_distances(&non_matching_requests, &state.matchers, requirements);
+        let request_distances = get_distances(&non_matching_requests, &state.matchers, requirements);
         let best_matches = get_min_distance_requests(&request_distances);
 
         let closes_match_request_idx = match best_matches.first() {
@@ -266,11 +259,7 @@ impl StateManager for HttpMockStateManager {
         let found_mock_id = result.map(|mock| mock.id);
 
         if let Some(found_id) = found_mock_id {
-            tracing::debug!(
-                "Matched mock with id={} to the following request: {:#?}",
-                found_id,
-                req
-            );
+            tracing::debug!("Matched mock with id={} to the following request: {:#?}", found_id, req);
 
             let mock = state.mocks.get_mut(&found_id).unwrap();
             mock.call_counter += 1;
@@ -278,10 +267,7 @@ impl StateManager for HttpMockStateManager {
             return Ok(Some(mock.definition.response.clone()));
         }
 
-        tracing::debug!(
-            "Could not match any mock to the following request: {:#?}",
-            req
-        );
+        tracing::debug!("Could not match any mock to the following request: {:#?}", req);
 
         Ok(None)
     }
@@ -410,8 +396,7 @@ impl StateManager for HttpMockStateManager {
 
         if let Some(rec) = state.recordings.get(&id) {
             return Ok(Some(
-                serialize_mock_defs_to_yaml(&rec.mocks)
-                    .map_err(|err| DataConversionError(err.to_string()))?,
+                serialize_mock_defs_to_yaml(&rec.mocks).map_err(|err| DataConversionError(err.to_string()))?,
             ));
         }
 
@@ -443,10 +428,7 @@ impl StateManager for HttpMockStateManager {
         Ok(mock_ids)
     }
 
-    fn find_forward_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveForwardingRule>, Error> {
+    fn find_forward_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveForwardingRule>, Error> {
         let state = self.state.lock().unwrap();
 
         let result = state
@@ -458,10 +440,7 @@ impl StateManager for HttpMockStateManager {
         Ok(result)
     }
 
-    fn find_proxy_rule<'a>(
-        &'a self,
-        req: &'a HttpMockRequest,
-    ) -> Result<Option<ActiveProxyRule>, Error> {
+    fn find_proxy_rule<'a>(&'a self, req: &'a HttpMockRequest) -> Result<Option<ActiveProxyRule>, Error> {
         let state = self.state.lock().unwrap();
 
         let result = state
@@ -495,14 +474,11 @@ impl StateManager for HttpMockStateManager {
             return Ok(());
         }
 
-        let res = res
-            .try_into()
-            .map_err(|err| DataConversionError(err.to_string()))?;
+        let res = res.try_into().map_err(|err| DataConversionError(err.to_string()))?;
 
         for id in recording_ids {
             let rec = state.recordings.get_mut(&id).unwrap();
-            let definition =
-                build_mock_definition(is_proxied, time_taken, &req, &res, &rec.config)?;
+            let definition = build_mock_definition(is_proxied, time_taken, &req, &res, &rec.config)?;
             rec.mocks.push(definition);
         }
 
@@ -524,12 +500,11 @@ fn build_mock_definition(
         let header_name_lowercase = header_name.to_lowercase();
         for (key, value) in request.headers() {
             if let Some(key) = key
-                && header_name_lowercase == key.to_string().to_lowercase() {
-                    let value = value
-                        .to_str()
-                        .map_err(|err| DataConversionError(err.to_string()))?;
-                    headers.push((header_name.to_string(), value.to_string()))
-                }
+                && header_name_lowercase == key.to_string().to_lowercase()
+            {
+                let value = value.to_str().map_err(|err| DataConversionError(err.to_string()))?;
+                headers.push((header_name.to_string(), value.to_string()))
+            }
         }
     }
 
@@ -570,11 +545,7 @@ fn build_mock_definition(
         },
         path: Some(request.uri().path().to_string()),
         method: Some(request.method().to_string()),
-        header: if !headers.is_empty() {
-            Some(headers)
-        } else {
-            None
-        },
+        header: if !headers.is_empty() { Some(headers) } else { None },
         body: if request.body().is_empty() {
             None
         } else {
@@ -604,9 +575,10 @@ fn validate_request_requirements(req: &RequestRequirements) -> Result<(), Error>
 
     if let Some(_body) = &req.body
         && let Some(method) = &req.method
-            && NON_BODY_METHODS.contains(&method.as_str()) {
-                return Err(BodyMethodInvalid);
-            }
+        && NON_BODY_METHODS.contains(&method.as_str())
+    {
+        return Err(BodyMethodInvalid);
+    }
     Ok(())
 }
 
@@ -616,9 +588,7 @@ fn request_matches(
     request_requirements: &RequestRequirements,
 ) -> bool {
     tracing::trace!("Matching incoming HTTP request");
-    matchers
-        .iter()
-        .all(|x| x.matches(req, request_requirements))
+    matchers.iter().all(|x| x.matches(req, request_requirements))
 }
 
 fn get_distances(
@@ -667,10 +637,7 @@ fn get_request_mismatches(
     mock_rr: &RequestRequirements,
     matchers: &Vec<Box<dyn Matcher + Sync + Send>>,
 ) -> Vec<Mismatch> {
-    matchers
-        .iter()
-        .flat_map(|mat| mat.mismatches(req, mock_rr))
-        .collect()
+    matchers.iter().flat_map(|mat| mat.mismatches(req, mock_rr)).collect()
 }
 
 #[cfg(test)]
@@ -716,9 +683,6 @@ mod tests {
     #[test]
     fn default_history_limit_is_preserved() {
         let manager = HttpMockStateManager::default();
-        assert_eq!(
-            manager.state.lock().unwrap().history_limit,
-            DEFAULT_HISTORY_LIMIT
-        );
+        assert_eq!(manager.state.lock().unwrap().history_limit, DEFAULT_HISTORY_LIMIT);
     }
 }

--- a/tests/examples/forwarding_tests.rs
+++ b/tests/examples/forwarding_tests.rs
@@ -17,11 +17,13 @@ fn forwarding_test() {
     // We configure our server to forward the request to the target host instead of
     // answering with a mocked response. The 'when' variable lets you configure
     // rules under which forwarding should take place.
-    server.forward_to(target_server.base_url(), |rule| {
-        rule.filter(|when| {
-            when.any_request(); // We want all requests to be forwarded.
-        });
-    });
+    server
+        .forward_to(target_server.base_url(), |rule| {
+            rule.filter(|when| {
+                when.any_request(); // We want all requests to be forwarded.
+            });
+        })
+        .unwrap();
 
     // Now let's send an HTTP request to the mock server. The request will be forwarded
     // to the target host, as we configured before.
@@ -35,6 +37,34 @@ fn forwarding_test() {
 // @example-end
 
 #[test]
+fn invalid_forwarding_target_is_rejected() {
+    let server = MockServer::start();
+
+    let result = server.forward_to("/relative", |_| {});
+
+    assert!(matches!(
+        result,
+        Err(httpmock::ServerAdapterError::UpstreamError(message))
+            if message.contains("forwarding target has no scheme")
+    ));
+}
+
+#[test]
+fn invalid_forwarding_header_is_rejected() {
+    let server = MockServer::start();
+
+    let result = server.forward_to("http://example.com", |rule| {
+        rule.add_request_header("invalid header", "value");
+    });
+
+    assert!(matches!(
+        result,
+        Err(httpmock::ServerAdapterError::UpstreamError(message))
+            if message.contains("invalid forwarding header name")
+    ));
+}
+
+#[test]
 fn forward_to_website() {
     // Let's create our mock server for the test
     let server = MockServer::start();
@@ -43,11 +73,13 @@ fn forward_to_website() {
     // host instead of answering with a mocked response. The 'when'
     // variable lets you configure rules under which forwarding
     // should take place.
-    server.forward_to("https://httpmock.rs", |rule| {
-        rule.filter(|when| {
-            when.any_request(); // Ensure all requests are forwarded.
-        });
-    });
+    server
+        .forward_to("https://httpmock.rs", |rule| {
+            rule.filter(|when| {
+                when.any_request(); // Ensure all requests are forwarded.
+            });
+        })
+        .unwrap();
 
     // Now let's send an HTTP request to the mock server. The request
     // will be forwarded to the GitHub API, as we configured before.

--- a/tests/examples/forwarding_tests.rs
+++ b/tests/examples/forwarding_tests.rs
@@ -7,7 +7,7 @@ fn forwarding_test() {
     // We will create this mock server to simulate a real service (e.g., GitHub, AWS, etc.).
     let target_server = MockServer::start();
     target_server.mock(|when, then| {
-        when.any_request();
+        when.header("x-forwarded-by", "httpmock");
         then.status(200).body("Hi from fake GitHub!");
     });
 
@@ -17,9 +17,9 @@ fn forwarding_test() {
     // We configure our server to forward the request to the target host instead of
     // answering with a mocked response. The 'when' variable lets you configure
     // rules under which forwarding should take place.
-    server
+    let mut forwarding_rule = server
         .forward_to(target_server.base_url(), |rule| {
-            rule.filter(|when| {
+            rule.add_request_header("x-forwarded-by", "httpmock").filter(|when| {
                 when.any_request(); // We want all requests to be forwarded.
             });
         })
@@ -33,6 +33,10 @@ fn forwarding_test() {
     let response = client.get(server.url("/get")).send().unwrap();
     assert_eq!(response.status().as_u16(), 200);
     assert_eq!(response.text().unwrap(), "Hi from fake GitHub!");
+
+    forwarding_rule.delete();
+    let response = client.get(server.url("/get")).send().unwrap();
+    assert_eq!(response.status().as_u16(), 404);
 }
 // @example-end
 
@@ -50,6 +54,19 @@ fn invalid_forwarding_target_is_rejected() {
 }
 
 #[test]
+fn unsupported_forwarding_target_scheme_is_rejected() {
+    let server = MockServer::start();
+
+    let result = server.forward_to("ftp://example.com", |_| {});
+
+    assert!(matches!(
+        result,
+        Err(httpmock::ServerAdapterError::UpstreamError(message))
+            if message.contains("expected http or https")
+    ));
+}
+
+#[test]
 fn invalid_forwarding_header_is_rejected() {
     let server = MockServer::start();
 
@@ -61,6 +78,21 @@ fn invalid_forwarding_header_is_rejected() {
         result,
         Err(httpmock::ServerAdapterError::UpstreamError(message))
             if message.contains("invalid forwarding header name")
+    ));
+}
+
+#[test]
+fn invalid_forwarding_header_value_is_rejected() {
+    let server = MockServer::start();
+
+    let result = server.forward_to("http://example.com", |rule| {
+        rule.add_request_header("x-test", "invalid\nvalue");
+    });
+
+    assert!(matches!(
+        result,
+        Err(httpmock::ServerAdapterError::UpstreamError(message))
+            if message.contains("invalid forwarding header value")
     ));
 }
 

--- a/tests/examples/record_and_playback_tests.rs
+++ b/tests/examples/record_and_playback_tests.rs
@@ -309,7 +309,7 @@ fn record_with_forwarding_all_request_parts_test() {
     );
 
     let recording_file_path = recording
-        .save("website-via-forwarding")
+        .save("website-via-forwarding-all-request-parts")
         .expect("cannot store recording on disk");
 
     // Start a new mock server instance for playback

--- a/tests/examples/record_and_playback_tests.rs
+++ b/tests/examples/record_and_playback_tests.rs
@@ -13,11 +13,13 @@ fn record_with_forwarding_test() {
     });
 
     let recording_server = MockServer::start();
-    recording_server.forward_to(target_server.base_url(), |rule| {
-        rule.filter(|when| {
-            when.path("/hello");
-        });
-    });
+    recording_server
+        .forward_to(target_server.base_url(), |rule| {
+            rule.filter(|when| {
+                when.path("/hello");
+            });
+        })
+        .unwrap();
 
     let recording = recording_server.record(|rule| {
         rule.record_response_delays(true)
@@ -138,11 +140,13 @@ fn record_with_forwarding_example_test() {
     // host instead of answering with a mocked response. The 'when'
     // variable lets you configure rules under which forwarding
     // should take place.
-    server.forward_to("https://httpmock.rs", |rule| {
-        rule.filter(|when| {
-            when.any_request(); // Ensure all requests are forwarded.
-        });
-    });
+    server
+        .forward_to("https://httpmock.rs", |rule| {
+            rule.filter(|when| {
+                when.any_request(); // Ensure all requests are forwarded.
+            });
+        })
+        .unwrap();
 
     let recording = server.record(|rule| {
         rule.filter(|when| {
@@ -201,11 +205,13 @@ fn playback_github_api() {
     // host (GitHub API) instead of responding with a mock. The 'rule'
     // parameter allows you to define conditions under which forwarding
     // should occur.
-    server.forward_to("https://httpmock.rs", |rule| {
-        rule.filter(|when| {
-            when.any_request(); // Forward all requests.
-        });
-    });
+    server
+        .forward_to("https://httpmock.rs", |rule| {
+            rule.filter(|when| {
+                when.any_request(); // Forward all requests.
+            });
+        })
+        .unwrap();
 
     // Set up recording to capture all forwarded requests and responses
     let recording = server.record(|rule| {
@@ -258,11 +264,13 @@ fn playback_github_api() {
 fn record_with_forwarding_all_request_parts_test() {
     let server = MockServer::start();
 
-    server.forward_to("https://httpmock.rs", |rule| {
-        rule.filter(|when| {
-            when.any_request(); // Ensure all requests are forwarded.
-        });
-    });
+    server
+        .forward_to("https://httpmock.rs", |rule| {
+            rule.filter(|when| {
+                when.any_request(); // Ensure all requests are forwarded.
+            });
+        })
+        .unwrap();
 
     let recording = server.record(|rule| {
         rule.record_request_headers(vec![String::from("X-Auth-Token"), String::from("Accept-Language")])

--- a/tests/misc/runtimes_test.rs
+++ b/tests/misc/runtimes_test.rs
@@ -64,7 +64,8 @@ async fn test_fn() -> u16 {
                 when.any_request();
             });
         })
-        .await;
+        .await
+        .unwrap();
 
     // Outer proxy
     let server1 = MockServer::start_async().await;


### PR DESCRIPTION
## Summary

This is a breaking change.

Forwarding targets and request headers are now validated when the rule is created and kept as typed internal state. This removes repeated parsing and the request-time unwraps.

`forward_to` and `forward_to_async` now return `Result` so invalid configuration is reported to the caller.

## Checks

- `cargo test --all-features --lib`
- `cargo test --features proxy --test lib forwarding_test`
- `cargo test --doc --features proxy`
- `cargo clippy --all-targets --all-features`
