### PR TITLE
style: enforce clippy::ptr_arg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ all = { level = "deny", priority = -1 }
 doc_overindented_list_items = "allow"
 to_string_in_format_args = "allow"
 new_ret_no_self = "allow"
-ptr_arg = "allow"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -543,7 +543,7 @@ fn validate_request_requirements(req: &RequestRequirements) -> Result<(), Error>
 }
 
 fn request_matches(
-    matchers: &Vec<Box<dyn Matcher + Sync + Send>>,
+    matchers: &[Box<dyn Matcher + Sync + Send>],
     req: &HttpMockRequest,
     request_requirements: &RequestRequirements,
 ) -> bool {
@@ -552,8 +552,8 @@ fn request_matches(
 }
 
 fn get_distances(
-    history: &Vec<&Arc<HttpMockRequest>>,
-    matchers: &Vec<Box<dyn Matcher + Sync + Send>>,
+    history: &[&Arc<HttpMockRequest>],
+    matchers: &[Box<dyn Matcher + Sync + Send>],
     mock_rr: &RequestRequirements,
 ) -> BTreeMap<usize, usize> {
     history
@@ -566,7 +566,7 @@ fn get_distances(
 fn get_request_distance(
     req: &Arc<HttpMockRequest>,
     mock_request_requirements: &RequestRequirements,
-    matchers: &Vec<Box<dyn Matcher + Sync + Send>>,
+    matchers: &[Box<dyn Matcher + Sync + Send>],
 ) -> usize {
     matchers
         .iter()
@@ -595,7 +595,7 @@ fn get_min_distance_requests(request_distances: &BTreeMap<usize, usize>) -> Vec<
 fn get_request_mismatches(
     req: &Arc<HttpMockRequest>,
     mock_rr: &RequestRequirements,
-    matchers: &Vec<Box<dyn Matcher + Sync + Send>>,
+    matchers: &[Box<dyn Matcher + Sync + Send>],
 ) -> Vec<Mismatch> {
     matchers.iter().flat_map(|mat| mat.mismatches(req, mock_rr)).collect()
 }


### PR DESCRIPTION
Removes `ptr_arg` from the Clippy allow-list and changes internal collection parameters from `&Vec<T>` to slices. Callers continue to work through normal slice coercion.

Depends on #238.

Checks: `cargo fmt --all -- --check`; `cargo +stable clippy --all-targets --all-features`.
