### PR TITLE
style: enforce clippy::useless_format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ new_ret_no_self = "allow"
 module_inception = "allow"
 unnecessary_to_owned = "allow"
 ptr_arg = "allow"
-useless_format = "allow"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Removes `useless_format` from the Clippy allow-list and passes the fallback certificate error message directly to `expect`. This tightens linting without changing runtime behavior.

Depends on #238.

Checks: `cargo fmt --all -- --check`; `cargo +stable clippy --all-targets --all-features`.
