### PR TITLE
style: enforce clippy::useless_borrows_in_formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ all = { level = "deny", priority = -1 }
 collapsible_if = "allow"
 uninlined_format_args = "allow"
 enum_variant_names = "allow"
-useless_borrows_in_formatting = "allow"
 doc_overindented_list_items = "allow"
 type_complexity = "allow"
 needless_return = "allow"


### PR DESCRIPTION
Removes `useless_borrows_in_formatting` from the Clippy allow-list and writes mismatch headings directly instead of borrowing an intermediate formatted string. Output remains unchanged.

Depends on #238.

Checks: `cargo +stable fmt --all -- --check`; `cargo +stable clippy --all-targets --all-features`.
