### PR TITLE
style: enforce clippy::doc_overindented_list_items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ unused_variables = "allow"
 # Gate all clippy lints. The allowed lints are a temporary allow list that should be removed
 # over time.
 all = { level = "deny", priority = -1 }
-doc_overindented_list_items = "allow"
 to_string_in_format_args = "allow"
 new_ret_no_self = "allow"
 ptr_arg = "allow"

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -818,17 +818,17 @@ impl MockServer {
     /// # Parameters
     ///
     /// * `rule`: A closure that takes a `RecordingRuleBuilder` as an argument,
-    ///           which defines the conditions under which HTTP requests and
-    ///           their corresponding responses will be recorded.
+    ///   which defines the conditions under which HTTP requests and
+    ///   their corresponding responses will be recorded.
     ///
     /// # Returns
     ///
     /// * `Recording`: A reference to the recording object stored on the mock server,
-    ///                which can be used to manage the recording, such as downloading
-    ///                or deleting it. The `Recording` object provides functionality
-    ///                to download the recording and store it under a file. Users can
-    ///                use these files for later playback by calling the `playback`
-    ///                method of the mock server.
+    ///   which can be used to manage the recording, such as downloading
+    ///   or deleting it. The `Recording` object provides functionality
+    ///   to download the recording and store it under a file. Users can
+    ///   use these files for later playback by calling the `playback`
+    ///   method of the mock server.
     ///
     /// # Example
     ///
@@ -903,16 +903,16 @@ impl MockServer {
     /// # Parameters
     ///
     /// * `rule`: A closure that takes a `RecordingRuleBuilder` as an argument,
-    ///           which defines the conditions under which requests will be recorded.
+    ///   which defines the conditions under which requests will be recorded.
     ///
     /// # Returns
     ///
     /// * `Recording`: A reference to the recording object stored on the mock server,
-    ///                which can be used to manage the recording, such as downloading
-    ///                or deleting it. The `Recording` object provides functionality
-    ///                to download the recording and store it under a file. Users can
-    ///                use these files for later playback by calling the `playback`
-    ///                method of the mock server.
+    ///   which can be used to manage the recording, such as downloading
+    ///   or deleting it. The `Recording` object provides functionality
+    ///   to download the recording and store it under a file. Users can
+    ///   use these files for later playback by calling the `playback`
+    ///   method of the mock server.
     ///
     /// # Example
     ///
@@ -1012,7 +1012,7 @@ impl MockServer {
     /// # Parameters
     ///
     /// * `path`: A path to the file containing the recording. This can be any type
-    ///           that implements `Into<PathBuf>`, such as a `&str` or `String`.
+    ///   that implements `Into<PathBuf>`, such as a `&str` or `String`.
     ///
     /// # Returns
     ///
@@ -1090,7 +1090,7 @@ impl MockServer {
     /// # Parameters
     ///
     /// * `path`: A path to the file containing the recorded interactions. This can be any type
-    ///           that implements `Into<PathBuf>`, such as a `&str` or `String`.
+    ///   that implements `Into<PathBuf>`, such as a `&str` or `String`.
     ///
     /// # Returns
     ///
@@ -1181,7 +1181,7 @@ impl MockServer {
     /// # Parameters
     ///
     /// * `content`: A YAML string that represents the contents of the recording file.
-    ///              This can be any type that implements `AsRef<str>`, such as a `&str` or `String`.
+    ///   This can be any type that implements `AsRef<str>`, such as a `&str` or `String`.
     ///
     /// # Returns
     ///
@@ -1239,7 +1239,7 @@ impl MockServer {
     /// # Parameters
     ///
     /// * `content`: A YAML string that represents the contents of the recording file.
-    ///              This can be any type that implements `AsRef<str>`, such as a `&str` or `String`.
+    ///   This can be any type that implements `AsRef<str>`, such as a `&str` or `String`.
     ///
     /// # Returns
     ///

--- a/src/server/matchers/comparison.rs
+++ b/src/server/matchers/comparison.rs
@@ -1296,7 +1296,7 @@ mod string_matches_regex_tests {
 ///
 /// # Returns
 /// * `usize` - The computed distance. In the negated case, it returns the number of characters that did match the regex.
-///             In the non-negated case, it returns the number of characters that did not match the regex.
+///   In the non-negated case, it returns the number of characters that did not match the regex.
 pub fn regex_string_distance(
     negated: bool,
     case_sensitive: bool,


### PR DESCRIPTION
Removes `doc_overindented_list_items` from the Clippy allow-list and corrects indentation in Rustdoc list continuations. This improves rendered documentation without changing its wording or runtime behavior.

Depends on #238.

Checks: `cargo +stable fmt --all -- --check`; `cargo +stable clippy --all-targets --all-features`.
