### PR TITLE
fix: avoid recording filename collisions

### DIFF
--- a/src/api/proxy.rs
+++ b/src/api/proxy.rs
@@ -6,7 +6,7 @@ use std::{cell::Cell, rc::Rc};
 use bytes::Bytes;
 
 #[cfg(feature = "record")]
-use crate::common::util::write_file;
+use crate::common::util::write_file_new;
 use crate::{
     When,
     api::server::MockServer,
@@ -116,6 +116,34 @@ impl<'a> ProxyRule<'a> {
 pub struct Recording<'a> {
     pub id: usize,
     pub(crate) server: &'a MockServer,
+}
+
+#[cfg(feature = "record")]
+async fn write_recording(
+    dir: &Path,
+    scenario: &str,
+    timestamp: u64,
+    content: &Bytes,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut collision_index = 0_u64;
+
+    loop {
+        let filename = if collision_index == 0 {
+            format!("{}_{}.yaml", scenario, timestamp)
+        } else {
+            format!("{}_{}_{}.yaml", scenario, timestamp, collision_index)
+        };
+
+        match write_file_new(dir.join(filename), content, true).await {
+            Ok(path) => return Ok(path),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                collision_index = collision_index
+                    .checked_add(1)
+                    .ok_or("could not find an available recording filename")?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
 }
 
 /// Represents a reference to a recording of HTTP interactions on a mock server.
@@ -230,11 +258,8 @@ impl<'a> Recording<'a> {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_secs();
-        let filename = format!("{}_{}.yaml", scenario, timestamp);
-        let filepath = dir.join(filename);
-
         if let Some(bytes) = rec {
-            return write_file(&filepath, &bytes, true).await;
+            return write_recording(dir, &scenario, timestamp, &bytes).await;
         }
 
         Err("No recording data available".into())
@@ -369,5 +394,41 @@ impl RecordingRuleBuilder {
         self.config.set(config);
 
         self
+    }
+}
+
+#[cfg(all(test, feature = "record"))]
+mod tests {
+    use std::{fs, time::SystemTime};
+
+    use bytes::Bytes;
+
+    use super::write_recording;
+    use crate::common::util::Join;
+
+    #[test]
+    fn recording_filenames_are_unique_within_the_same_second() {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "httpmock-recording-filename-test-{}-{unique}",
+            std::process::id()
+        ));
+
+        let first = write_recording(&dir, "scenario", 1, &Bytes::from_static(b"first"))
+            .join()
+            .unwrap();
+        let second = write_recording(&dir, "scenario", 1, &Bytes::from_static(b"second"))
+            .join()
+            .unwrap();
+
+        assert_eq!(first.file_name().unwrap(), "scenario_1.yaml");
+        assert_eq!(second.file_name().unwrap(), "scenario_1_1.yaml");
+        assert_eq!(fs::read(&first).unwrap(), b"first");
+        assert_eq!(fs::read(&second).unwrap(), b"second");
+
+        fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -104,11 +104,11 @@ pub fn get_test_resource_file_path(relative_resource_path: &str) -> Result<PathB
     }
 }
 
-pub async fn write_file<P: AsRef<Path>>(
+pub async fn write_file_new<P: AsRef<Path>>(
     resource_path: P,
     content: &Bytes,
     create_dir: bool,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
+) -> std::io::Result<PathBuf> {
     let mut path = resource_path.as_ref().to_path_buf();
 
     if path.is_relative() {
@@ -120,7 +120,7 @@ pub async fn write_file<P: AsRef<Path>>(
         create_dir_all(parent)?;
     }
 
-    let mut file = File::create(&path)?;
+    let mut file = File::options().write(true).create_new(true).open(&path)?;
     file.write_all(content)?;
     file.flush()?;
 


### PR DESCRIPTION
Recording filenames currently use second-resolution timestamps, so concurrent saves with the same scenario can target the same path and truncate each other. This makes file creation atomic and retries collisions with a numeric suffix while preserving the existing filename when it is available.

This prevents parallel doctests and user code from overwriting recordings.

Checks:

- `cargo +stable test --features record recording_filenames_are_unique_within_the_same_second`
- `rustfmt +stable --edition 2024 --check src/api/proxy.rs src/common/util.rs`
- `cargo +stable clippy --all-targets --all-features`
