### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,6 +16,9 @@ on:
 
 name: Docker Release
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/httpmock/httpmock/security/code-scanning/22](https://github.com/httpmock/httpmock/security/code-scanning/22)

Add an explicit `permissions` block to the workflow so token scope is documented and locked to least privilege regardless of repo/org defaults.

Best fix here: add workflow-level permissions right after `name:` (or before `jobs:`), setting:
- `contents: read`

This preserves existing behavior (checkout still works) while preventing unintended write scopes on `GITHUB_TOKEN`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
