### PR TITLE
style: enforce clippy::collapsible_if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ unused_variables = "allow"
 # Gate all clippy lints. The allowed lints are a temporary allow list that should be removed
 # over time.
 all = { level = "deny", priority = -1 }
-collapsible_if = "allow"
 uninlined_format_args = "allow"
 enum_variant_names = "allow"
 useless_borrows_in_formatting = "allow"


### PR DESCRIPTION
## What changed

- remove `clippy::collapsible_if` from the temporary allow list
- enforce the lint through the existing `clippy::all` deny gate

## Why

The current codebase already satisfies this lint, so the exception is no longer needed. Removing it prevents future collapsible nested conditionals from being introduced.

## Impact

This changes lint enforcement only; runtime behavior and the public API are unchanged.

## Validation

- `cargo clippy --all-targets --all-features -- -A clippy::double_must_use`
