### PR TITLE
style: enforce clippy::unnecessary_to_owned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ to_string_in_format_args = "allow"
 extra_unused_lifetimes = "allow"
 new_ret_no_self = "allow"
 module_inception = "allow"
-unnecessary_to_owned = "allow"
 ptr_arg = "allow"
 useless_format = "allow"
 


### PR DESCRIPTION
## What changed

- remove `clippy::unnecessary_to_owned` from the temporary allow list
- enforce the lint through the existing `clippy::all` deny gate

## Why

The current codebase already satisfies this lint, so the exception is no longer needed. Removing it prevents avoidable owned-value conversions from being introduced.

## Impact

This changes lint enforcement only; runtime behavior and the public API are unchanged.

## Validation

- `cargo clippy --all-targets --all-features -- -A clippy::double_must_use`
