### PR TITLE
style: simplify internal error variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ unused_variables = "allow"
 all = { level = "deny", priority = -1 }
 collapsible_if = "allow"
 uninlined_format_args = "allow"
-enum_variant_names = "allow"
 useless_borrows_in_formatting = "allow"
 doc_overindented_list_items = "allow"
 type_complexity = "allow"

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -21,7 +21,7 @@ pub type RequestPredicate = Arc<dyn Fn(&HttpMockRequest) -> bool + Send + Sync>;
 
 use crate::{
     common::{
-        data::Error::{HeaderDeserializationError, RequestConversionError, StaticMockConversionError},
+        data::Error::{HeaderDeserialization, RequestConversion, StaticMockConversion},
         util::HttpMockBytes,
     },
     server::{RequestMetadata, matchers::generic::MatchingStrategy},
@@ -30,19 +30,13 @@ use crate::{
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Cannot deserialize header: {0}")]
-    HeaderDeserializationError(String),
-    #[error("Cookie parser error: {0}")]
-    CookieParserError(String),
+    HeaderDeserialization(String),
     #[error("cannot convert to/from static mock: {0}")]
-    StaticMockConversionError(String),
-    #[error("JSONConversionError: {0}")]
-    JSONConversionError(#[from] serde_json::Error),
-    #[error("Invalid request data: {0}")]
-    InvalidRequestData(String),
+    StaticMockConversion(String),
     #[error("Cannot convert request to/from internal structure: {0}")]
-    RequestConversionError(String),
+    RequestConversion(String),
     #[error("Response conversion error: {0}")]
-    ResponseConversionError(String),
+    ResponseConversion(String),
 }
 
 /// A general abstraction of an HTTP request of `httpmock`.
@@ -293,7 +287,7 @@ fn http_headers_to_vec<T>(req: &http::Request<T>) -> Result<Vec<(String, String)
         .iter()
         .map(|(name, value)| {
             // Attempt to convert the HeaderValue to a &str, returning an error if it fails.
-            let value_str = value.to_str().map_err(|e| RequestConversionError(e.to_string()))?;
+            let value_str = value.to_str().map_err(|e| RequestConversion(e.to_string()))?;
             Ok((name.as_str().to_string(), value_str.to_string()))
         })
         .collect()
@@ -421,20 +415,20 @@ impl TryFrom<&HttpMockResponse> for http::Response<bytes::Bytes> {
     fn try_from(res: &HttpMockResponse) -> Result<Self, Self::Error> {
         let raw_status = res
             .status
-            .ok_or_else(|| Error::ResponseConversionError("missing status".into()))?;
+            .ok_or_else(|| Error::ResponseConversion("missing status".into()))?;
 
         let status = http::StatusCode::from_u16(raw_status)
-            .map_err(|_| Error::ResponseConversionError(format!("invalid status: {}", raw_status)))?;
+            .map_err(|_| Error::ResponseConversion(format!("invalid status: {}", raw_status)))?;
 
         let mut builder = http::Response::builder().status(status);
 
         if let Some(headers) = &res.headers {
             for (name, value) in headers {
                 let header_name = http::header::HeaderName::try_from(name.clone())
-                    .map_err(|_| Error::ResponseConversionError(format!("invalid header name: {}", name)))?;
+                    .map_err(|_| Error::ResponseConversion(format!("invalid header name: {}", name)))?;
 
                 let header_value = http::header::HeaderValue::try_from(value.clone()).map_err(|_| {
-                    Error::ResponseConversionError(format!("invalid header value for '{}': {}", name, value))
+                    Error::ResponseConversion(format!("invalid header value for '{}': {}", name, value))
                 })?;
 
                 builder = builder.header(header_name, header_value);
@@ -445,7 +439,7 @@ impl TryFrom<&HttpMockResponse> for http::Response<bytes::Bytes> {
 
         builder
             .body(body)
-            .map_err(|e| Error::ResponseConversionError(format!("http build error: {}", e)))
+            .map_err(|e| Error::ResponseConversion(format!("http build error: {}", e)))
     }
 }
 
@@ -526,7 +520,7 @@ where
             let name = name.as_str().to_string();
             let val = value
                 .to_str()
-                .map_err(|_| Error::ResponseConversionError(format!("non-utf8 header value for '{}'", name)))?;
+                .map_err(|_| Error::ResponseConversion(format!("non-utf8 header value for '{}'", name)))?;
             headers.push((name, val.to_string()));
         }
 
@@ -660,9 +654,7 @@ impl TryFrom<&http::Response<Bytes>> for MockServerHttpResponse {
         let mut headers = Vec::with_capacity(value.headers().len());
 
         for (key, value) in value.headers() {
-            let value = value
-                .to_str()
-                .map_err(|err| HeaderDeserializationError(err.to_string()))?;
+            let value = value.to_str().map_err(|err| HeaderDeserialization(err.to_string()))?;
 
             headers.push((key.as_str().to_string(), value.to_string()))
         }
@@ -1615,7 +1607,7 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
 
         let mut method = None;
         if let Some(method_str) = value.request.method {
-            method = Some(Method::from_str(&method_str).map_err(|err| StaticMockConversionError(err.to_string()))?);
+            method = Some(Method::from_str(&method_str).map_err(|err| StaticMockConversion(err.to_string()))?);
         }
 
         Ok(StaticMockDefinition {

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -17,14 +17,12 @@ use crate::server::RequestMetadata;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error("cannot read response body: {0}")]
+    ResponseBodyRead(#[from] hyper::Error),
     #[error("cannot send request: {0}")]
-    HyperError(#[from] hyper::Error),
-    #[error("cannot send request: {0}")]
-    HyperUtilError(#[from] hyper_util::client::legacy::Error),
+    RequestSend(#[from] hyper_util::client::legacy::Error),
     #[error("runtime error: {0}")]
-    RuntimeError(#[from] tokio::task::JoinError),
-    #[error("unknown error")]
-    Unknown,
+    TaskJoin(#[from] tokio::task::JoinError),
 }
 
 #[async_trait]

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -31,8 +31,8 @@ use crate::{
     prelude::{HttpMockRequest, HttpMockResponse},
     server::{
         handler::Error::{
-            InvalidHeader, ParamError, ParamFormatError, RequestBodyDeserializeError, RequestConversionError,
-            ResponseBodyConversionError, ResponseBodySerializeError, ResponseDataConversionError,
+            InvalidHeader, InvalidParamFormat, MissingParam, RequestBodyDeserialization, RequestConversion,
+            ResponseBodyConstruction, ResponseBodySerialization, ResponseDataConversion,
         },
         state,
         state::StateManager,
@@ -41,35 +41,27 @@ use crate::{
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("cannot parse regex: {0}")]
-    RegexError(#[from] regex::Error),
     #[error("cannot deserialize request body: {0}")]
-    RequestBodyDeserializeError(serde_json::Error),
-    #[error("cannot process request body: {0}")]
-    RequestBodyError(String),
+    RequestBodyDeserialization(#[source] serde_json::Error),
     #[error("cannot serialize response body: {0}")]
-    ResponseBodySerializeError(serde_json::Error),
+    ResponseBodySerialization(#[source] serde_json::Error),
+    #[error("cannot construct response: {0}")]
+    ResponseBodyConstruction(#[source] http::Error),
     #[error("cannot convert response body: {0}")]
-    ResponseBodyConversionError(http::Error),
-    #[error("cannot convert response body: {0}")]
-    ResponseDataConversionError(data::Error),
+    ResponseDataConversion(#[source] data::Error),
     #[error("expected URL parameters not found")]
-    ParamError,
+    MissingParam,
     #[error("URL parameter format is invalid: {0}")]
-    ParamFormatError(String),
-    #[error("cannot modify state: {0}")]
-    StateManagerError(#[from] state::Error),
-    #[error("invalid status code: {0}")]
-    InvalidStatusCode(#[from] http::status::InvalidStatusCode),
+    InvalidParamFormat(String),
+    #[error("state operation failed: {0}")]
+    State(#[from] state::Error),
     #[error("cannot convert request to internal data structure: {0}")]
-    RequestConversionError(String),
+    RequestConversion(String),
     #[cfg(any(feature = "remote", feature = "proxy"))]
     #[error("failed to send HTTP request: {0}")]
-    HttpClientError(#[from] HttpClientError),
+    HttpClient(#[from] HttpClientError),
     #[error("invalid header: {0}")]
     InvalidHeader(String),
-    #[error("unknown error")]
-    Unknown,
 }
 
 enum RoutePath {
@@ -358,7 +350,7 @@ where
     #[cfg(feature = "record")]
     fn handle_load_recording(&self, req: Request<Bytes>) -> Result<Response<Bytes>, Error> {
         let recording_file_content =
-            std::str::from_utf8(req.body()).map_err(|err| RequestConversionError(err.to_string()))?;
+            std::str::from_utf8(req.body()).map_err(|err| RequestConversion(err.to_string()))?;
 
         let rec = self.state.load_mocks_from_recording(recording_file_content)?;
         response(StatusCode::OK, Some(rec))
@@ -367,7 +359,7 @@ where
     async fn catch_all(&self, req: Request<Bytes>) -> Result<Response<Bytes>, Error> {
         let internal_request: HttpMockRequest = (&req)
             .try_into()
-            .map_err(|err: DataError| RequestConversionError(err.to_string()))?;
+            .map_err(|err: DataError| RequestConversion(err.to_string()))?;
 
         #[cfg(feature = "record")]
         let start = Instant::now();
@@ -482,7 +474,7 @@ where
             });
 
         // Convert via your TryFrom<HttpMockResponse> impl
-        let http_resp: http::Response<bytes::Bytes> = resp_def.try_into().map_err(ResponseDataConversionError)?;
+        let http_resp: http::Response<bytes::Bytes> = resp_def.try_into().map_err(ResponseDataConversion)?;
 
         Ok(http_resp)
     }
@@ -496,12 +488,12 @@ where
     for (n, v) in tree_path.params() {
         if n.eq(name) {
             let parse_result: Result<T, T::Err> = v.parse::<T>();
-            let parsed_value = parse_result.map_err(|e| ParamFormatError(format!("{:?}", e)))?;
+            let parsed_value = parse_result.map_err(|e| InvalidParamFormat(format!("{:?}", e)))?;
             return Ok(parsed_value);
         }
     }
 
-    Err(ParamError)
+    Err(MissingParam)
 }
 
 fn response<T>(status: StatusCode, body: Option<T>) -> Result<Response<Bytes>, Error>
@@ -513,21 +505,19 @@ where
     if let Some(body_obj) = body {
         builder = builder.header("content-type", "application/json");
 
-        let body_bytes = serde_json::to_vec(&body_obj).map_err(ResponseBodySerializeError)?;
+        let body_bytes = serde_json::to_vec(&body_obj).map_err(ResponseBodySerialization)?;
 
-        return builder
-            .body(Bytes::from(body_bytes))
-            .map_err(ResponseBodyConversionError);
+        return builder.body(Bytes::from(body_bytes)).map_err(ResponseBodyConstruction);
     }
 
-    builder.body(Bytes::new()).map_err(ResponseBodyConversionError)
+    builder.body(Bytes::new()).map_err(ResponseBodyConstruction)
 }
 
 fn parse_json_body<T>(req: Request<Bytes>) -> Result<T, Error>
 where
     T: DeserializeOwned,
 {
-    let body: T = serde_json::from_slice(req.body().as_ref()).map_err(RequestBodyDeserializeError)?;
+    let body: T = serde_json::from_slice(req.body().as_ref()).map_err(RequestBodyDeserialization)?;
     Ok(body)
 }
 
@@ -558,7 +548,7 @@ pub fn to_origin_form(mut req: Request<Bytes>) -> Result<Request<Bytes>, Error> 
         let new_uri = Uri::builder()
             .path_and_query(path_and_query)
             .build()
-            .map_err(|e| RequestConversionError(e.to_string()))?;
+            .map_err(|e| RequestConversion(e.to_string()))?;
         *req.uri_mut() = new_uri;
     }
 

--- a/src/server/persistence.rs
+++ b/src/server/persistence.rs
@@ -15,7 +15,7 @@ use crate::{
         data::{MockDefinition, StaticMockDefinition},
     },
     server::{
-        persistence::Error::{DeserializationError, FileReadError},
+        persistence::Error::{Deserialization, FileRead},
         state,
         state::{Error::DataConversionError, StateManager},
     },
@@ -24,13 +24,13 @@ use crate::{
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("cannot read from mock file: {0}")]
-    FileReadError(String),
+    FileRead(String),
     #[error("cannot modify state: {0}")]
-    StateError(#[from] state::Error),
+    State(#[from] state::Error),
     #[error("cannot deserialize YAML: {0}")]
-    DeserializationError(String),
+    Deserialization(String),
     #[error("cannot convert data structures: {0}")]
-    DataConversionError(#[from] data::Error),
+    DataConversion(#[from] data::Error),
 }
 
 pub fn read_static_mock_definitions<S>(path_opt: PathBuf, state: &S) -> Result<(), Error>
@@ -59,7 +59,7 @@ fn read_static_mocks(path: PathBuf) -> Result<Vec<StaticMockDefinition>, Error> 
 
         tracing::info!("Loading static mock file from '{}'", file_path.to_string_lossy());
 
-        let content = read_to_string(file_path).map_err(|err| FileReadError(err.to_string()))?;
+        let content = read_to_string(file_path).map_err(|err| FileRead(err.to_string()))?;
 
         definitions.extend(deserialize_mock_defs_from_yaml(&content)?);
     }
@@ -71,10 +71,10 @@ pub fn deserialize_mock_defs_from_yaml(yaml_content: &str) -> Result<Vec<StaticM
     let mut definitions = Vec::new();
 
     for document in Deserializer::from_str(yaml_content) {
-        let value = YamlValue::deserialize(document).map_err(|err| DeserializationError(err.to_string()))?;
+        let value = YamlValue::deserialize(document).map_err(|err| Deserialization(err.to_string()))?;
 
         let definition: StaticMockDefinition =
-            serde_yaml::from_value(value).map_err(|err| DeserializationError(err.to_string()))?;
+            serde_yaml::from_value(value).map_err(|err| Deserialization(err.to_string()))?;
 
         definitions.push(definition);
     }

--- a/src/server/persistence.rs
+++ b/src/server/persistence.rs
@@ -6,7 +6,7 @@ use std::{
 
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::Deserialize;
-use serde_yaml::{Deserializer, Value as YamlValue};
+use serde_yaml::Deserializer;
 use thiserror::Error;
 
 use crate::{
@@ -14,21 +14,27 @@ use crate::{
         data,
         data::{MockDefinition, StaticMockDefinition},
     },
-    server::{
-        persistence::Error::{Deserialization, FileRead},
-        state,
-        state::{Error::DataConversionError, StateManager},
-    },
+    server::{state, state::StateManager},
 };
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("cannot read from mock file: {0}")]
-    FileRead(String),
-    #[error("cannot modify state: {0}")]
+    #[error("cannot read static mock directory '{}': {source}", path.display())]
+    DirectoryRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("cannot read static mock file '{}': {source}", path.display())]
+    FileRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("state operation failed: {0}")]
     State(#[from] state::Error),
-    #[error("cannot deserialize YAML: {0}")]
-    Deserialization(String),
+    #[error("cannot process YAML: {0}")]
+    Yaml(#[from] serde_yaml::Error),
     #[error("cannot convert data structures: {0}")]
     DataConversion(#[from] data::Error),
 }
@@ -47,9 +53,17 @@ where
 fn read_static_mocks(path: PathBuf) -> Result<Vec<StaticMockDefinition>, Error> {
     let mut definitions: Vec<StaticMockDefinition> = Vec::new();
 
-    let paths = read_dir(path).expect("cannot list files in directory");
+    let paths = read_dir(&path).map_err(|source| Error::DirectoryRead {
+        path: path.clone(),
+        source,
+    })?;
     for file_path in paths {
-        let file_path = file_path.unwrap().path();
+        let file_path = file_path
+            .map_err(|source| Error::DirectoryRead {
+                path: path.clone(),
+                source,
+            })?
+            .path();
         if let Some(ext) = file_path.extension()
             && !"yaml".eq(ext)
             && !"yml".eq(ext)
@@ -59,7 +73,10 @@ fn read_static_mocks(path: PathBuf) -> Result<Vec<StaticMockDefinition>, Error> 
 
         tracing::info!("Loading static mock file from '{}'", file_path.to_string_lossy());
 
-        let content = read_to_string(file_path).map_err(|err| FileRead(err.to_string()))?;
+        let content = read_to_string(&file_path).map_err(|source| Error::FileRead {
+            path: file_path,
+            source,
+        })?;
 
         definitions.extend(deserialize_mock_defs_from_yaml(&content)?);
     }
@@ -71,12 +88,7 @@ pub fn deserialize_mock_defs_from_yaml(yaml_content: &str) -> Result<Vec<StaticM
     let mut definitions = Vec::new();
 
     for document in Deserializer::from_str(yaml_content) {
-        let value = YamlValue::deserialize(document).map_err(|err| Deserialization(err.to_string()))?;
-
-        let definition: StaticMockDefinition =
-            serde_yaml::from_value(value).map_err(|err| Deserialization(err.to_string()))?;
-
-        definitions.push(definition);
+        definitions.push(StaticMockDefinition::deserialize(document)?);
     }
 
     Ok(definitions)
@@ -90,9 +102,8 @@ pub fn serialize_mock_defs_to_yaml(mocks: &[MockDefinition]) -> Result<Bytes, Er
             buffer.put_slice(b"---\n");
         }
 
-        let static_mock: StaticMockDefinition =
-            StaticMockDefinition::try_from(mock).map_err(|err| DataConversionError(err.to_string()))?;
-        let yaml = serde_yaml::to_string(&static_mock).map_err(|err| DataConversionError(err.to_string()))?;
+        let static_mock = StaticMockDefinition::try_from(mock)?;
+        let yaml = serde_yaml::to_string(&static_mock)?;
         buffer.put_slice(yaml.as_bytes());
     }
 


### PR DESCRIPTION
## What changed

- remove eight internal error variants that were never constructed
- name the remaining variants after the operation that failed instead of repeating `Error`, giving `RequestSend`, `ResponseBodyRead`, `TaskJoin`, `MissingParam`, `ResponseBodyConstruction` and so on
- keep the typed source errors, using `#[from]` where the mapping is unambiguous
- report static mock directory and file failures with their paths instead of panicking
- deserialize static mock definitions directly so the YAML parser's locations survive
- remove `clippy::enum_variant_names` from the temporary allow list

## Why

Names like `RequestConversionError` and `FileReadError` repeat what `Error::...` already says. A straight rename would have kept the dead variants and the implementation-oriented names along with them, so this drops the variants with no construction path and names the rest after what failed. Both the matches and the messages read better for it.

`#[from]` is limited to the unambiguous mappings: YAML, state, and data conversion. Operation-dependent errors stay explicitly mapped so they keep their context. Static mock I/O errors keep the path, which also removes two panics.

## Compatibility

Not source-breaking downstream. The affected enums live in private modules and `server::Error` is unchanged. Diagnostics and debug output read better, and a bad static mock path now returns an error instead of panicking.

## Validation

- `cargo +stable clippy --all-targets --all-features`
- `cargo +stable clippy --all-targets --no-default-features`
- `cargo +stable test --all-features --lib`
- `cargo +stable fmt --all -- --check`
- `git diff --check`
