### PR TITLE
style: enforce unused_variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ rust-version = "1.88.0"
 warnings = { level = "deny", priority = -1 }
 unsafe_code = "forbid"
 dead_code = "allow"
-unused_variables = "allow"
 
 [lints.clippy]
 # Gate all clippy lints. The allowed lints are a temporary allow list that should be removed

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -352,8 +352,9 @@ impl Handler {
         #[cfg(feature = "record")]
         let start = Instant::now();
 
+        // The second element records whether a proxy rule served the request.
         #[cfg(feature = "proxy")]
-        let (res, is_proxied) = if let Some(rule) = self.state.find_forward_rule(&internal_request)? {
+        let res = if let Some(rule) = self.state.find_forward_rule(&internal_request)? {
             (self.forward(rule, req).await?, false)
         } else if let Some(rule) = self.state.find_proxy_rule(&internal_request)? {
             (self.proxy(rule, req).await?, true)
@@ -362,12 +363,12 @@ impl Handler {
         };
 
         #[cfg(not(feature = "proxy"))]
-        let (res, is_proxied) = (self.serve_mock(&internal_request).await?, false);
+        let res = (self.serve_mock(&internal_request).await?, false);
 
         #[cfg(feature = "record")]
-        self.state.record(is_proxied, start.elapsed(), internal_request, &res)?;
+        self.state.record(res.1, start.elapsed(), internal_request, &res.0)?;
 
-        Ok(res)
+        Ok(res.0)
     }
 
     #[cfg(feature = "proxy")]

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -352,9 +352,8 @@ impl Handler {
         #[cfg(feature = "record")]
         let start = Instant::now();
 
-        // The second element records whether a proxy rule served the request.
         #[cfg(feature = "proxy")]
-        let res = if let Some(rule) = self.state.find_forward_rule(&internal_request)? {
+        let dispatch = if let Some(rule) = self.state.find_forward_rule(&internal_request)? {
             (self.forward(rule, req).await?, false)
         } else if let Some(rule) = self.state.find_proxy_rule(&internal_request)? {
             (self.proxy(rule, req).await?, true)
@@ -363,12 +362,19 @@ impl Handler {
         };
 
         #[cfg(not(feature = "proxy"))]
-        let res = (self.serve_mock(&internal_request).await?, false);
+        let dispatch = (self.serve_mock(&internal_request).await?, false);
 
         #[cfg(feature = "record")]
-        self.state.record(res.1, start.elapsed(), internal_request, &res.0)?;
+        let (response, is_proxied) = dispatch;
 
-        Ok(res.0)
+        #[cfg(not(feature = "record"))]
+        let (response, _) = dispatch;
+
+        #[cfg(feature = "record")]
+        self.state
+            .record(is_proxied, start.elapsed(), internal_request, &response)?;
+
+        Ok(response)
     }
 
     #[cfg(feature = "proxy")]


### PR DESCRIPTION
## What changed

- keep the dispatch result as a tuple until the feature-dependent values are bound
- destructure it as `(response, is_proxied)` when `record` is enabled and as `(response, _)` otherwise
- remove `unused_variables` from the temporary allow list

## Why

`is_proxied` comes out of the dispatch chain in `HttpMockHandler::handle`, but only the recording path reads it. Naming it unconditionally therefore left an unused binding in two configurations: `proxy` without `record`, and neither feature.

The flag cannot be dropped from recording builds. `record` passes it to `build_mock_definition`, which uses it to decide whether the recorded definition carries a host, port, and scheme, so both its `true` and `false` values are meaningful.

The dispatch chain remains shared across feature configurations. A small cfg-aware destructuring step introduces the descriptive `is_proxied` name only where it is consumed, while non-recording builds explicitly ignore that tuple element.

## Impact

Runtime behavior is unchanged. Forwarded requests and plain mock responses record `false`; proxied requests record `true`. Builds now enforce `unused_variables` instead of allowing it globally.

## Validation

- `cargo clippy --all-targets --all-features`
- `cargo clippy --all-targets`
- `cargo clippy --all-targets --no-default-features`
- `cargo clippy --all-targets --no-default-features --features proxy`
- `cargo clippy --all-targets --no-default-features --features record`
- `cargo clippy --all-targets --no-default-features --features standalone`
- `cargo hack check --feature-powerset --depth 2 --all-targets`
- `cargo test --all-features --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
