### PR TITLE
feat: reduce dependency tree by ~30% for default and minimal builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- The dependency tree has been reduced significantly (about 30% fewer crates in default builds, see
+  [#46](https://github.com/httpmock/httpmock/issues/46)). Behavior change: the mock server now only
+  accepts HTTP/2 connections when the `http2` cargo feature is enabled. Previously, cleartext
+  HTTP/2 with prior knowledge (e.g. gRPC clients) was accepted even without this feature, because
+  an internal dependency unconditionally enabled HTTP/2 support. Enable the `http2` feature to
+  keep serving such clients.
+
 ## Version 0.8.3
 
 Minimum supported Rust version has been raised to 1.88.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,11 @@ new_ret_no_self = "allow"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_regex = "1"
 base64 = "0.23"
 regex = "1"
 tracing = { version = "0.1", features = ["log"] }
-stringmetrics = "2"
 assert-json-diff = "2"
 async-trait = "0.1"
-async-object-pool = "0.2"
-futures-util = "0.3"
 similar = "3"
 form_urlencoded = "1"
 thiserror = "2"
@@ -43,10 +39,9 @@ path-tree = ">=0.8.0, <0.8.4"
 http = "1"
 bytes = { version = "1", features = ["serde"] }
 hyper = { version = "1", features = ["server", "http1", "client"] }
-hyper-util = { version = "0.1", features = ["tokio", "server", "http1", "server-auto"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "http1"] }
 http-body-util = "0.1"
-tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "signal", "net"] }
-tabwriter = "1"
+tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "net"] }
 colored = { version = "3", optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 serde_yaml = { version = "0.9", optional = true }
@@ -72,14 +67,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 default = ["cookies"]
-standalone =  ["clap", "tracing-subscriber", "record", "http2", "cookies", "remote", "remote-https"] # enables standalone mode
+standalone =  ["clap", "tokio/signal", "tracing-subscriber", "record", "http2", "cookies", "remote", "remote-https"] # enables standalone mode
 color = ["colored"] # enables colorful output in standalone mode
 cookies = ["headers"] # enables support for matching cookies
 remote = ["hyper-util/client-legacy", "hyper-util/http2"] # allows to connect to remote mock servers
 remote-https = ["remote", "rustls", "rustls/ring", "hyper-rustls", "hyper-rustls/ring", "hyper-rustls/http2"] # allows to connect to remote mock servers via HTTPS
 proxy = ["remote-https", "hyper-util/client-legacy", "hyper-util/http2", "hyper-rustls", "hyper-rustls/http2"] # enables proxy functionality
 https = ["rustls", "rcgen", "tokio-rustls", "hyper-rustls", "rustls-pki-types", "rustls/ring", "hyper-rustls/ring", "tls-detect", "if-addrs"] # enables httpmock server support for TLS/HTTPS
-http2 = ["hyper/http2", "hyper-util/http2"] # enables httpmocks server support for HTTP2
+http2 = ["hyper/http2", "hyper-util/http2", "hyper-util/server-auto"] # enables httpmocks server support for HTTP2
 record = ["proxy", "serde_yaml"]
 experimental = [] # marker feature for experimental features
 

--- a/src/api/output.rs
+++ b/src/api/output.rs
@@ -1,8 +1,7 @@
-use std::io::Write;
+use std::fmt::Write;
 
 #[cfg(feature = "color")]
 use colored::Colorize;
-use tabwriter::TabWriter;
 
 use crate::{
     common::{
@@ -16,6 +15,78 @@ use crate::{
 };
 
 const QUOTED_TEXT: &str = "quoted for better readability";
+
+/// A writer that aligns `\t`-separated columns of consecutive tab-containing lines
+/// (elastic tab stops) when the buffered text is retrieved via [`TabWriter::into_string`].
+///
+/// This is a simplified replacement for the `tabwriter` crate that produces identical
+/// output for the patterns this module generates. It measures cell width in `char`s
+/// rather than display columns, so cells containing wide characters (e.g. CJK) may
+/// align differently in terminals.
+struct TabWriter {
+    buf: String,
+}
+
+impl TabWriter {
+    fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    fn into_string(self) -> String {
+        let mut out_lines: Vec<String> = Vec::new();
+        let mut block: Vec<&str> = Vec::new();
+
+        for line in self.buf.split('\n') {
+            if line.contains('\t') {
+                block.push(line);
+            } else {
+                Self::align_block(&mut block, &mut out_lines);
+                out_lines.push(line.to_string());
+            }
+        }
+        Self::align_block(&mut block, &mut out_lines);
+
+        out_lines.join("\n")
+    }
+
+    /// Aligns the columns of a block of consecutive tab-containing lines and clears the block.
+    fn align_block(block: &mut Vec<&str>, out_lines: &mut Vec<String>) {
+        let rows: Vec<Vec<&str>> = block.drain(..).map(|line| line.split('\t').collect()).collect();
+
+        // Compute the width of each column. The last cell of a row is never padded,
+        // so it does not contribute to its column's width. The minimum column width of 2
+        // matches the `tabwriter` crate's default, which this replaces: most visibly, it
+        // renders the empty cell of lines starting with `\t` as a 4-space indent.
+        let column_count = rows.iter().map(|cells| cells.len()).max().unwrap_or(0);
+        let mut widths = vec![2; column_count];
+        for cells in &rows {
+            for (idx, cell) in cells.iter().enumerate() {
+                if idx + 1 < cells.len() {
+                    widths[idx] = widths[idx].max(cell.chars().count());
+                }
+            }
+        }
+
+        for cells in &rows {
+            let mut line = String::new();
+            for (idx, cell) in cells.iter().enumerate() {
+                line.push_str(cell);
+                if idx + 1 < cells.len() {
+                    let padding = widths[idx] - cell.chars().count() + 2;
+                    line.push_str(&" ".repeat(padding));
+                }
+            }
+            out_lines.push(line);
+        }
+    }
+}
+
+impl Write for TabWriter {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.buf.push_str(s);
+        Ok(())
+    }
+}
 
 pub fn fail_with(actual_hits: usize, expected_hits: usize, closest_match: Option<ClosestMatch>) {
     let closest_match = closest_match.expect("No request has been received by the mock server.");
@@ -51,7 +122,7 @@ pub fn fail_with(actual_hits: usize, expected_hits: usize, closest_match: Option
 }
 
 pub fn create_mismatch_output(idx: usize, mismatch: &Mismatch) -> (String, Option<(String, String)>) {
-    let mut tw = TabWriter::new(vec![]);
+    let mut tw = TabWriter::new();
     let mut ide_diff_left = String::new();
     let mut ide_diff_right = String::new();
 
@@ -73,9 +144,7 @@ pub fn create_mismatch_output(idx: usize, mismatch: &Mismatch) -> (String, Optio
 
     write_footer(&mut tw, mismatch);
 
-    tw.flush().unwrap();
-
-    let output = String::from_utf8(tw.into_inner().unwrap()).unwrap();
+    let output = tw.into_string();
 
     if !ide_diff_left.is_empty() && !ide_diff_right.is_empty() {
         return (output, Some((ide_diff_left, ide_diff_right)));
@@ -84,14 +153,14 @@ pub fn create_mismatch_output(idx: usize, mismatch: &Mismatch) -> (String, Optio
     (output, None)
 }
 
-fn write_header(tw: &mut TabWriter<Vec<u8>>, idx: usize, mismatch: &Mismatch) {
+fn write_header(tw: &mut TabWriter, idx: usize, mismatch: &Mismatch) {
     writeln!(tw, "{}", "-".repeat(60)).unwrap();
     writeln!(tw, "{} : {} Mismatch ", idx + 1, title_case(&mismatch.entity)).unwrap();
     writeln!(tw, "{}", "-".repeat(60)).unwrap();
 }
 
 fn handle_single_value_comparison(
-    tw: &mut TabWriter<Vec<u8>>,
+    tw: &mut TabWriter,
     mismatch: &Mismatch,
     comparison: &SingleValueComparison,
 ) -> (String, String) {
@@ -108,7 +177,7 @@ fn handle_single_value_comparison(
 }
 
 fn handle_key_value_comparison(
-    tw: &mut TabWriter<Vec<u8>>,
+    tw: &mut TabWriter,
     mismatch: &Mismatch,
     comparison: &KeyValueComparison,
 ) -> (String, String) {
@@ -202,7 +271,7 @@ fn handle_key_value_comparison(
     (String::new(), String::new())
 }
 
-fn print_all_request_values(tw: &mut TabWriter<Vec<u8>>, entity: &str, all: &[KeyValueComparisonKeyValuePair]) {
+fn print_all_request_values(tw: &mut TabWriter, entity: &str, all: &[KeyValueComparisonKeyValuePair]) {
     if all.is_empty() {
         return;
     }
@@ -221,7 +290,7 @@ fn print_all_request_values(tw: &mut TabWriter<Vec<u8>>, entity: &str, all: &[Ke
     }
 }
 
-fn print_value_not_in_request(tw: &mut TabWriter<Vec<u8>>, matching_strategy: &Option<MatchingStrategy>) {
+fn print_value_not_in_request(tw: &mut TabWriter, matching_strategy: &Option<MatchingStrategy>) {
     writeln!(
         tw,
         "\n{}",
@@ -236,7 +305,7 @@ fn print_value_not_in_request(tw: &mut TabWriter<Vec<u8>>, matching_strategy: &O
     .unwrap();
 }
 
-fn handle_function_comparison(tw: &mut TabWriter<Vec<u8>>, mismatch: &Mismatch, comparison: &FunctionComparison) {
+fn handle_function_comparison(tw: &mut TabWriter, mismatch: &Mismatch, comparison: &FunctionComparison) {
     writeln!(
         tw,
         "Custom matcher function {} with index {} did not match the request",
@@ -245,7 +314,7 @@ fn handle_function_comparison(tw: &mut TabWriter<Vec<u8>>, mismatch: &Mismatch, 
     .unwrap();
 }
 
-fn write_footer(tw: &mut TabWriter<Vec<u8>>, mismatch: &Mismatch) {
+fn write_footer(tw: &mut TabWriter, mismatch: &Mismatch) {
     let mut version = env!("CARGO_PKG_VERSION");
     if version.trim().is_empty() {
         version = "latest";

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -9,7 +9,6 @@ use std::{
     thread,
 };
 
-use async_object_pool::Pool;
 use tokio::sync::oneshot::channel;
 
 #[cfg(feature = "remote")]
@@ -30,6 +29,7 @@ use crate::{
     },
     common::{
         data::{MockDefinition, MockServerHttpResponse, RequestRequirements},
+        pool::Pool,
         runtime,
         util::{Join, read_env, with_retry},
     },
@@ -1319,7 +1319,7 @@ impl Drop for MockServer {
     /// This behavior is part of the `MockServer` struct and does not require any additional features to be enabled.
     fn drop(&mut self) {
         let adapter = self.server_adapter.take().unwrap();
-        self.pool.put(adapter).join();
+        self.pool.put(adapter);
     }
 }
 

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -1,5 +1,3 @@
-extern crate serde_regex;
-
 use std::{
     cmp::Ordering,
     convert::{TryFrom, TryInto},
@@ -736,9 +734,23 @@ impl fmt::Debug for MockServerHttpResponse {
     }
 }
 
+/// (De)serializes a [`regex::Regex`] as its pattern string.
+mod regex_string {
+    use serde::{Deserialize, Deserializer, Serializer, de::Error};
+
+    pub fn serialize<S: Serializer>(value: &regex::Regex, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(value.as_str())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<regex::Regex, D::Error> {
+        let pattern = std::borrow::Cow::<str>::deserialize(deserializer)?;
+        pattern.parse().map_err(Error::custom)
+    }
+}
+
 /// A general abstraction of an HTTP request for all handlers.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct HttpMockRegex(#[serde(with = "serde_regex")] pub regex::Regex);
+pub struct HttpMockRegex(#[serde(with = "regex_string")] pub regex::Regex);
 
 impl Ord for HttpMockRegex {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -42,10 +42,11 @@ impl HttpMockHttpClient {
     #[cfg(any(feature = "remote-https", feature = "https"))]
     pub fn new(runtime: Option<Arc<Runtime>>) -> Self {
         // see https://github.com/rustls/rustls/issues/1938
+        // `install_default` fails if a default provider is already installed, including
+        // when a concurrently created client wins the race to install it. Either way a
+        // default provider is in place afterwards, so the error can be ignored.
         if rustls::crypto::CryptoProvider::get_default().is_none() {
-            rustls::crypto::ring::default_provider()
-                .install_default()
-                .expect("cannot install rustls crypto provider");
+            let _ = rustls::crypto::ring::default_provider().install_default();
         }
 
         let builder = hyper_rustls::HttpsConnectorBuilder::new()

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod data;
+pub(crate) mod pool;
 pub(crate) mod runtime;
 pub mod util;
 

--- a/src/common/pool.rs
+++ b/src/common/pool.rs
@@ -1,0 +1,120 @@
+use std::sync::Mutex;
+
+use tokio::sync::Semaphore;
+
+/// A simple async object pool holding up to `capacity` objects.
+///
+/// [`Pool::take_or_create`] returns a pooled object, or creates a new one if the pool has
+/// spare capacity. When `capacity` objects are already handed out, it waits asynchronously
+/// until one is returned via [`Pool::put`].
+///
+/// This implementation must stay runtime agnostic, because it is used on the client side
+/// where user code may run on any async runtime (e.g., smol or actix-rt, see
+/// `tests/misc/runtimes_test.rs`). It therefore only uses `tokio::sync` primitives, which
+/// are runtime agnostic (they do not require the tokio reactor or timer, unlike
+/// `tokio::time`, `tokio::net`, etc.).
+pub struct Pool<T> {
+    items: Mutex<Vec<T>>,
+    // Each permit represents the right to hold one of the pool's objects. Waiting for a
+    // permit is what suspends callers while all objects are handed out.
+    permits: Semaphore,
+}
+
+impl<T> Pool<T> {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            items: Mutex::new(Vec::new()),
+            permits: Semaphore::new(capacity.min(Semaphore::MAX_PERMITS)),
+        }
+    }
+
+    pub async fn take_or_create<F>(&self, create: F) -> T
+    where
+        F: Fn() -> T,
+    {
+        let permit = self.permits.acquire().await.expect("object pool semaphore was closed");
+
+        let existing = self.items.lock().expect("object pool lock poisoned").pop();
+        // `create` may block for a while (e.g., starting a mock server), so call it
+        // outside of the lock. If it panics, the still-attached permit is released on
+        // unwind, so the pool's capacity is not reduced by failed creation attempts.
+        let item = existing.unwrap_or_else(create);
+
+        // The permit is restored by `put` when the object is returned to the pool.
+        permit.forget();
+        item
+    }
+
+    pub fn put(&self, item: T) {
+        self.items.lock().expect("object pool lock poisoned").push(item);
+        self.permits.add_permits(1);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::Pool;
+
+    #[tokio::test]
+    async fn reuses_returned_objects() {
+        let created = AtomicUsize::new(0);
+        let pool = Pool::new(5);
+
+        let first = pool.take_or_create(|| created.fetch_add(1, Ordering::SeqCst)).await;
+        pool.put(first);
+        let second = pool.take_or_create(|| created.fetch_add(1, Ordering::SeqCst)).await;
+
+        assert_eq!(first, second);
+        assert_eq!(created.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn waits_for_returned_object_when_capacity_reached() {
+        let pool = Arc::new(Pool::new(1));
+
+        let taken = pool.take_or_create(|| 1).await;
+
+        let waiter = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.take_or_create(|| unreachable!("pool is at capacity")).await })
+        };
+
+        // Let the spawned task run until it suspends waiting for a permit.
+        tokio::task::yield_now().await;
+
+        // The waiter cannot obtain an object until the first one is returned.
+        assert!(!waiter.is_finished());
+        pool.put(taken);
+        assert_eq!(waiter.await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn panicking_creator_does_not_reduce_capacity() {
+        let pool = Arc::new(Pool::new(1));
+
+        let panicking = {
+            let pool = pool.clone();
+            tokio::spawn(async move { pool.take_or_create(|| panic!("creation failed")).await })
+        };
+        assert!(panicking.await.is_err());
+
+        // The failed creation attempt must not consume the pool's only permit.
+        assert_eq!(pool.take_or_create(|| 42).await, 42);
+    }
+
+    // The pool must not depend on the tokio runtime (see module documentation).
+    #[test]
+    fn works_without_tokio_runtime() {
+        smol::block_on(async {
+            let pool = Pool::new(1);
+            let value = pool.take_or_create(|| 42).await;
+            pool.put(value);
+            assert_eq!(pool.take_or_create(|| 0).await, 42);
+        });
+    }
+}

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -15,7 +15,6 @@ use std::{
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use bytes::Bytes;
 use futures_timer::Delay;
-use futures_util::pin_mut;
 use serde::{Deserialize, Serialize};
 
 // ===============================================================================================
@@ -87,8 +86,7 @@ impl<F: Future> Join for F {
         let waker = Waker::from(Arc::new(ThreadWaker(thread::current())));
         let mut context = Context::from_waker(&waker);
 
-        let future = self;
-        pin_mut!(future);
+        let mut future = std::pin::pin!(self);
 
         loop {
             match future.as_mut().poll(&mut context) {

--- a/src/server/matchers/comparators.rs
+++ b/src/server/matchers/comparators.rs
@@ -11,9 +11,9 @@ use crate::{
     server::matchers::{
         comparison,
         comparison::{
-            distance_for, distance_for_prefix, distance_for_substring, distance_for_suffix, equal_weight_distance_for,
-            hostname_equals, regex_unmatched_length, string_contains, string_distance, string_equals,
-            string_has_prefix, string_has_suffix,
+            distance_for, distance_for_prefix, distance_for_substring, distance_for_suffix, hostname_equals,
+            regex_unmatched_length, string_contains, string_distance, string_equals, string_has_prefix,
+            string_has_suffix,
         },
     },
 };
@@ -92,7 +92,7 @@ impl ValueComparator<Value, Value> for JSONContainsMatchComparator {
     fn distance(&self, mock_value: &Option<&Value>, req_value: &Option<&Value>) -> usize {
         let mv_bytes = mock_value.map_or(Vec::new(), |v| v.to_string().into_bytes());
         let rv_bytes = req_value.map_or(Vec::new(), |v| v.to_string().into_bytes());
-        let distance = equal_weight_distance_for(&mv_bytes, &rv_bytes);
+        let distance = distance_for(&mv_bytes, &rv_bytes);
 
         if self.negated {
             std::cmp::max(mv_bytes.len(), rv_bytes.len()) - distance
@@ -551,12 +551,12 @@ impl ValueComparator<HttpMockBytes, HttpMockBytes> for BytesPrefixComparator {
 
         // Compare only up to the length of the mock_slice
         let compared_window = std::cmp::min(mock_slice.len(), req_slice.len());
-        let distance = equal_weight_distance_for(&mock_slice[..compared_window], &req_slice[..compared_window]);
+        let distance = distance_for(&mock_slice[..compared_window], &req_slice[..compared_window]);
 
         // if negated, we want to find out how many
         if self.negated {
-            // This is why we need the equal_weight_distance_for function:
-            // to calculate the distance as the number of differing characters.
+            // The Levenshtein distance of two equally sized windows is the number of
+            // differing characters, so this counts the matching characters.
             compared_window - distance
         } else {
             distance
@@ -603,15 +603,15 @@ impl ValueComparator<HttpMockBytes, HttpMockBytes> for BytesSuffixComparator {
 
         // Compare only up to the length of the mock_slice
         let compared_window = std::cmp::min(mock_slice.len(), req_slice.len());
-        let distance = equal_weight_distance_for(
+        let distance = distance_for(
             &mock_slice[..compared_window],
             &req_slice[req_slice.len() - compared_window..],
         );
 
         // if negated, we want to find out how many
         if self.negated {
-            // This is why we need the equal_weight_distance_for function:
-            // to calculate the distance as the number of differing characters.
+            // The Levenshtein distance of two equally sized windows is the number of
+            // differing characters, so this counts the matching characters.
             compared_window - distance
         } else {
             distance

--- a/src/server/matchers/comparison.rs
+++ b/src/server/matchers/comparison.rs
@@ -1,7 +1,6 @@
 use std::{convert::TryInto, ops::Deref};
 
 use regex::Regex;
-use stringmetrics::LevWeights;
 
 use crate::common::{data::HttpMockRegex, util::HttpMockBytes};
 
@@ -805,7 +804,7 @@ pub fn string_distance(
         (mock_slice.to_lowercase(), req_slice.to_lowercase())
     };
 
-    let distance = equal_weight_distance_for(mock_slice.as_bytes(), req_slice.as_bytes());
+    let distance = distance_for(mock_slice.as_bytes(), req_slice.as_bytes());
 
     if negated {
         std::cmp::max(mock_slice.len(), req_slice.len()) - distance
@@ -911,29 +910,55 @@ mod string_distance_tests {
 // *************************************************************************************************
 // Helper functions
 // *************************************************************************************************
+/// Computes the Levenshtein distance between two sequences.
 pub fn distance_for<T>(expected: &[T], actual: &[T]) -> usize
 where
     T: PartialEq + Sized,
 {
-    stringmetrics::levenshtein_limit_iter(expected.iter(), actual.iter(), u32::MAX) as usize
-}
+    // Trim the common prefix and suffix first: distances are often computed between
+    // large, mostly identical values (e.g. request bodies), where trimming reduces the
+    // quadratic algorithm below to the small differing middle part. Trimming does not
+    // change the result, because an optimal edit sequence never touches equal
+    // leading/trailing parts.
+    let prefix_len = expected.iter().zip(actual).take_while(|(e, a)| e == a).count();
+    let (expected, actual) = (&expected[prefix_len..], &actual[prefix_len..]);
 
-pub fn equal_weight_distance_for<T>(expected: &[T], actual: &[T]) -> usize
-where
-    T: PartialEq + Sized,
-{
-    stringmetrics::try_levenshtein_weight_iter(
-        expected.iter(),
-        actual.iter(),
-        u32::MAX,
-        &LevWeights {
-            insertion: 1,
-            deletion: 1,
-            substitution: 1,
-        },
-    )
-    // Option=None is only returned in case limit is maxed out here it realistically can't
-    .expect("character limit exceeded") as usize
+    let suffix_len = expected
+        .iter()
+        .rev()
+        .zip(actual.iter().rev())
+        .take_while(|(e, a)| e == a)
+        .count();
+    let (a, b) = (
+        &expected[..expected.len() - suffix_len],
+        &actual[..actual.len() - suffix_len],
+    );
+
+    // The distance is symmetric, so let `b` be the shorter sequence to bound the DP row
+    // allocation below by the shorter operand (e.g. a small expected value compared
+    // against a large request body).
+    let (a, b) = if a.len() < b.len() { (b, a) } else { (a, b) };
+
+    // The classic single-row dynamic programming algorithm. row[j] holds the distance
+    // between the first `i` elements of `a` (0 before the outer loop's first iteration)
+    // and the first `j` elements of `b`.
+    let mut row: Vec<usize> = (0..=b.len()).collect();
+
+    for (i, a_elem) in a.iter().enumerate() {
+        let mut diagonal = row[0];
+        row[0] = i + 1;
+
+        for (j, b_elem) in b.iter().enumerate() {
+            let substitution = diagonal + usize::from(a_elem != b_elem);
+            let insertion = row[j] + 1;
+            let deletion = row[j + 1] + 1;
+
+            diagonal = row[j + 1];
+            row[j + 1] = substitution.min(insertion).min(deletion);
+        }
+    }
+
+    row[b.len()]
 }
 
 pub fn regex_unmatched_length(text: &str, re: &HttpMockRegex) -> usize {

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -2,10 +2,10 @@ use std::{
     future::{Future, pending},
     io,
     net::SocketAddr,
+    pin::Pin,
     sync::Arc,
 };
 
-use futures_util::{FutureExt, future::BoxFuture};
 use http::{Request, StatusCode};
 use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use hyper::{
@@ -14,7 +14,9 @@ use hyper::{
     http,
     service::service_fn,
 };
-use hyper_util::{rt::tokio::TokioIo, server::conn::auto::Builder as ServerBuilder};
+use hyper_util::rt::tokio::TokioIo;
+#[cfg(feature = "http2")]
+use hyper_util::server::conn::auto::Builder as ServerBuilder;
 #[cfg(feature = "https")]
 use rustls::ServerConfig;
 use thiserror::Error;
@@ -130,7 +132,7 @@ impl HttpMockServer {
     where
         F: Future<Output = ()>,
     {
-        let shutdown = shutdown.shared();
+        let mut shutdown = std::pin::pin!(shutdown);
         let server = Arc::new(self);
 
         loop {
@@ -150,7 +152,7 @@ impl HttpMockServer {
                         },
                     };
                 }
-                _ = shutdown.clone() => {
+                _ = &mut shutdown => {
                     break;
                 }
             }
@@ -338,37 +340,55 @@ where
 // task that calls `serve_tls_connection` -> `serve_connection` again for CONNECT/upgrade
 // tunneling. Any opaque `impl Future` return type here would need to resolve itself through
 // that indirect cycle, which rustc cannot do ("cycle detected when computing type of opaque
-// type"), surfacing as cascading bogus "is not Send" errors. Returning a `BoxFuture` erases
+// type"), surfacing as cascading bogus "is not Send" errors. Returning a boxed future erases
 // the concrete type and breaks the cycle. This runs once per TCP connection (not per
 // request, unlike `service`), so the extra heap allocation is negligible.
 fn serve_connection<S>(
     server: Arc<HttpMockServer>,
     stream: S,
     scheme: &'static str,
-) -> BoxFuture<'static, Result<(), Error>>
+) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     Box::pin(async move {
-        let mut server_builder = ServerBuilder::new(TokioExecutor::new());
+        let service = service_fn(|mut req| {
+            // We pass authority None here since we don't know it for non-CONNECT requests
+            // yet. We only know it when the full request has been buffered in `service()`.
+            // Here, we only the scheme is known from the connection type.
+            req.extensions_mut().insert(RequestMetadata::new(scheme));
+            server.clone().service(req)
+        });
 
-        server_builder.http1().preserve_header_case(true);
-        server_builder.http2();
-        //.enable_connect_protocol();
+        #[cfg(feature = "http2")]
+        {
+            let mut server_builder = ServerBuilder::new(TokioExecutor::new());
 
-        server_builder
-            .serve_connection_with_upgrades(
-                TokioIo::new(stream),
-                service_fn(|mut req| {
-                    // We pass authority None here since we don't know it for non-CONNECT requests
-                    // yet. We only know it when the full request has been buffered in `service()`.
-                    // Here, we only the scheme is known from the connection type.
-                    req.extensions_mut().insert(RequestMetadata::new(scheme));
-                    server.clone().service(req)
-                }),
-            )
-            .await
-            .map_err(ServerConnectionError)
+            server_builder.http1().preserve_header_case(true);
+            server_builder.http2();
+
+            server_builder
+                .serve_connection_with_upgrades(TokioIo::new(stream), service)
+                .await
+                .map_err(ServerConnectionError)
+        }
+
+        #[cfg(not(feature = "http2"))]
+        {
+            // Without the `http2` feature we use hyper's plain HTTP/1 connection builder
+            // instead of hyper-util's `auto` builder: `hyper-util/server-auto`
+            // unconditionally enables `hyper/http2`, which would pull the `h2` dependency
+            // subtree into builds that opted out of HTTP/2.
+            let mut server_builder = hyper::server::conn::http1::Builder::new();
+
+            server_builder.preserve_header_case(true);
+
+            server_builder
+                .serve_connection(TokioIo::new(stream), service)
+                .with_upgrades()
+                .await
+                .map_err(|e| ServerConnectionError(Box::new(e)))
+        }
     })
 }
 
@@ -396,6 +416,7 @@ fn to_service_response(response: Response<Bytes>) -> Result<Response<BoxBody<Byt
     Ok(Response::from_parts(parts, full(body)))
 }
 
+#[cfg(feature = "http2")]
 use hyper_util::rt::TokioExecutor;
 #[cfg(feature = "https")]
 use tls_detect::is_encrypted;


### PR DESCRIPTION
Closes #46 (revives the old dependency-reduction effort; `isahc`/`async-std` from the original report are long gone, this addresses what remained).

## Results

| Build | Before | After | |
|---|---|---|---|
| `--no-default-features` | 74 crates | **52 crates** | −30% |
| default features | 86 crates | **64 crates** | −26% |

## Changes

- **Gate `hyper-util/server-auto` behind the `http2` feature.** It unconditionally enabled `hyper/http2`, pulling the `h2` subtree (`indexmap`, `hashbrown`, `equivalent`, `fnv`, `slab`, `tokio-util`, `atomic-waker`) into every build regardless of the `http2` feature. Without `http2`, the server now uses hyper's plain `http1::Builder` with `.with_upgrades()` (CONNECT tunneling still works; verified by the https/proxy tests).
- **Replace `async-object-pool` with a small in-crate pool** (`src/common/pool.rs`, −5 crates): `std::sync::Mutex<Vec<T>>` + `tokio::sync::Semaphore`, which is reactor-free and therefore runtime-agnostic — unit tests cover reuse, blocking at capacity, panic-safe creation, and operation under smol without a tokio runtime.
- **Drop `futures-util`** (−5 crates): `.shared()` → `std::pin::pin!` + `&mut` re-polling in `select!`; `pin_mut!` → `std::pin::pin!`; `BoxFuture` spelled out.
- **Inline three small helpers** (−4 crates): `tabwriter` (+`unicode-width`), `stringmetrics`, `serde_regex`.
- **Move `tokio/signal` into the `standalone` feature** (−1 crate): only the binary uses signal handling.
- **Fix a latent `CryptoProvider` install race** in `src/common/http.rs`: check-then-install could panic when two clients were created concurrently. The old pool masked it by serializing creation under its lock.

## Verification

- Differential-tested the Levenshtein replacement against `stringmetrics` (20,000 randomized cases across both original call sites — exact agreement), and the tab alignment against `tabwriter` (byte-identical output for all patterns this crate emits, including the `minwidth: 2` default).
- Two review rounds applied: fixed a pool permit leak on creator panic, restored `stringmetrics`' prefix/suffix trimming (avoids O(n·m) blowup on large bodies), bounded the DP row by the shorter operand, `Semaphore::MAX_PERMITS` clamp, and assorted cleanups.
- `cargo test` passes for default, `--no-default-features`, and `--all-features`; `cargo check` passes for `standalone`, `https`, `http2`, `remote`, `record`; clippy and rustfmt clean.

## Behavior change

Cleartext HTTP/2 prior-knowledge connections (e.g. gRPC clients) now require the `http2` feature — previously they worked in every build only because `server-auto` force-enabled HTTP/2. Documented in CHANGELOG.md. Known cosmetic limitation: the inlined tab alignment measures `char`s instead of Unicode display columns; this can only affect failure-report alignment when user data contains both a literal tab and wide characters (noted in a doc comment).
