### PR TITLE
docs: document case-sensitive body matching introduced in v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,13 @@ The following pull requests have been merged:
 
 ## Version 0.8.0
 This release includes refactoring, dependency updates, and internal cleanups.
-No breaking changes expected.
 
 The minimum required Rust version has been increased to 1.82.
+
+### BREAKING CHANGES
+- [When::body](https://docs.rs/httpmock/latest/httpmock/struct.When.html#method.body) now compares the
+  request body byte-by-byte and is therefore case-sensitive. Up to and including version 0.7, this matcher
+  performed a case-insensitive string comparison (see [#224](https://github.com/httpmock/httpmock/issues/224)).
 
 The following pull requests have been merged:
 - [#172](https://github.com/httpmock/httpmock/pull/172): "Update Rust edition to 2021" (thanks [@FalkWoldmann](https://github.com/FalkWoldmann))

--- a/src/api/spec.rs
+++ b/src/api/spec.rs
@@ -2956,7 +2956,12 @@ impl When {
     /// Sets the required HTTP request body content.
     /// This method specifies that the HTTP request body must match the provided content exactly.
     ///
-    /// **Note**: The body content is case-sensitive and must be an exact match.
+    /// **Note**: The body content is compared byte-by-byte and is therefore case-sensitive
+    /// and must be an exact match.
+    ///
+    /// **Attention**: Up to and including version 0.7 of this library, this matcher performed a
+    /// case-insensitive string comparison. Since version 0.8, the request body is compared
+    /// byte-by-byte and the comparison is case-sensitive.
     ///
     /// # Parameters
     /// - `body`: The required HTTP request body content. This parameter accepts any type that can be converted into a `String`.
@@ -2999,7 +3004,8 @@ impl When {
     /// Sets the condition that the HTTP request body content must not match the specified value.
     /// This method ensures that the request body does not contain the provided content exactly.
     ///
-    /// **Note**: The body content is case-sensitive and must be an exact mismatch.
+    /// **Note**: The body content is compared byte-by-byte and is therefore case-sensitive
+    /// and must be an exact mismatch.
     ///
     /// # Parameters
     /// - `body`: The body content that the HTTP request must not contain. This parameter accepts any type that can be converted into a `String`.

--- a/tests/matchers/body.rs
+++ b/tests/matchers/body.rs
@@ -34,6 +34,24 @@ fn body_fail_message() {
     )
 }
 
+// The body matcher compares byte-by-byte and hence is case-sensitive since v0.8.0
+// (see https://github.com/httpmock/httpmock/issues/224).
+#[test]
+fn body_case_sensitive() {
+    run_test(
+        "case sensitivity",
+        |when| when.body("test"),
+        "TEST",
+        Some(vec![
+            "Expected body equals:",
+            "test",
+            "",
+            "Received:",
+            "TEST",
+        ]),
+    )
+}
+
 #[test]
 fn body_not() {
     for (idx, data) in generate_data().attribute_not.iter().enumerate() {


### PR DESCRIPTION
Fixes #224.

The `When::body` matcher performed a case-insensitive string comparison up to and including v0.7. Since v0.8.0, it compares the request body byte-by-byte and is therefore case-sensitive. This was an undocumented breaking change that caused tests relying on case-insensitive matching to fail after upgrading.

As discussed in the issue, the byte-level matching is the preferred behavior, so this PR keeps it and documents the change instead:

- Adds a **BREAKING CHANGES** note to the v0.8.0 section of the changelog (which previously stated "No breaking changes expected").
- Clarifies in the `When::body` and `When::body_not` documentation that the comparison is byte-level and case-sensitive, including a note about the behavior change between v0.7 and v0.8. The website documentation is generated from these doc comments and picks this up automatically.
- Adds a regression test (`body_case_sensitive`) pinning the case-sensitive behavior.