### PR TITLE
ci: deploy docs website on release instead of every master push

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,10 +1,11 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch’s name
-  push:
-    branches: [ master ]
+  # Deploy the website only when a release is published, so the published docs
+  # always reflect the latest release rather than every change on master.
+  # The workflow checks out the commit the release tag points to.
+  release:
+    types: [ published ]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
@@ -20,6 +21,8 @@ concurrency:
 
 jobs:
   build:
+    # Skip pre-releases; only full releases (and manual runs) update the website.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,9 +1,16 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Deploy the website only when a release is published, so the published docs
+  # Deploy the website only when a GitHub release is published, so the docs
   # always reflect the latest release rather than every change on master.
-  # The workflow checks out the commit the release tag points to.
+  #
+  # "published" is NOT a branch — it is an activity type of the "release"
+  # event. The release event also fires for other activities (created,
+  # edited, deleted, prereleased, released), e.g. when release notes are
+  # edited; filtering on "published" makes the workflow run exactly once,
+  # at the moment a release (or a previously drafted release) goes public.
+  # GitHub then checks out the commit the release tag points to, so the
+  # site is built from the released state of the repository.
   release:
     types: [ published ]
   # Allows you to run this workflow manually from the Actions tab on GitHub.


### PR DESCRIPTION
## Problem

The GitHub Pages deployment (`deploy-docs.yml`) ran on every push to `master`, so the published website could show documentation for changes that are not part of any release yet.

## Changes

- The workflow now triggers on `release: published` instead of `push` to `master`. GitHub checks out the commit the release tag points to, so the site is built from exactly the released state.
- Pre-releases are skipped via a job-level guard; only full releases update the website.
- Manual deployment via `workflow_dispatch` from the Actions tab remains available as an escape hatch.

## Behavior after merge

Publishing a release on GitHub becomes the signal that deploys the website. Draft releases do nothing until published. Pushes to `master` no longer touch the website.