### PR TITLE
ci: test the full feature power set in the nightly feature matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
       # catches most of what full matrix *testing* would. cargo-hack drops
       # combinations that are equivalent under feature implications (e.g.
       # record -> proxy -> remote-https -> remote), keeping the run small.
-      # The same power set is fully tested in feature-matrix.yml.
+      # The full power set (all depths, not just pairs) is tested nightly in
+      # feature-matrix.yml.
       #
       # Without dev-dependencies first: dev-dep feature unification can mask
       # gating bugs in the published crate.

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -2,8 +2,8 @@
 # integration run against a real Dockerised standalone server.
 #
 # This is too slow to block every PR, so it runs on pushes to master, on a
-# nightly schedule, and on demand. PRs get a compile-only check of the same
-# power set from ci.yml, which catches most feature-gating mistakes.
+# nightly schedule, and on demand. PRs get a compile-only check of the pairwise
+# subset from ci.yml, which catches most feature-gating mistakes.
 name: Feature Matrix
 
 on:
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   powerset-test:
-    name: Power set tests (shard ${{ matrix.partition }} of 4)
+    name: Power set tests (shard ${{ matrix.partition }} of 10)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v7
 
@@ -50,13 +50,16 @@ jobs:
         with:
           tool: cargo-hack
 
-      # Test every feature alone and every feature pair. Deeper combinations
-      # add little: the features form an implication chain
-      # (record -> proxy -> remote-https -> remote, standalone -> most others),
-      # so cargo-hack collapses equivalent combos and pairs already cover the
-      # realistic interactions. --partition spreads the combinations across
-      # four parallel shards.
-      - run: cargo hack test --feature-powerset --depth 2 --partition ${{ matrix.partition }}/4
+      # Test the full feature power set: some bugs only surface when an
+      # unexpected combination of features is enabled, so no --depth limit
+      # here. cargo-hack already collapses combinations that are equivalent
+      # under feature implications (record -> proxy -> remote-https -> remote,
+      # standalone -> most others), which keeps the set at ~128 combinations.
+      # `experimental` is excluded because it is an empty marker feature that
+      # gates no code; including it would double the matrix without adding
+      # coverage (drop the exclusion once it gates real code). --partition
+      # spreads the combinations across ten parallel shards.
+      - run: cargo hack test --feature-powerset --exclude-features experimental --partition ${{ matrix.partition }}/10
 
   docker-integration:
     name: Integration against Dockerised server


### PR DESCRIPTION
Some bugs only surface when an unexpected combination of features is enabled, and the current depth-2 matrix only ever tests single features and pairs. This deepens the nightly feature-matrix lane to the full power set:

- `cargo hack test --feature-powerset` now runs without a `--depth` limit, so every meaningful combination is tested (e.g. `remote-https` + `https`, `cookies` + `https` + `record`, ...). cargo-hack still collapses combinations that are equivalent under feature implications (`record -> proxy -> remote-https -> remote`, `standalone -> most others`), which keeps the set at ~128 combinations instead of 2^10.
- `experimental` is excluded from the power set: it is an empty marker feature that gates no code, so including it would double the matrix without adding any coverage. The workflow comment notes to drop the exclusion once it gates real code.
- The shard count goes from 4 to 10 so the per-shard load (~13 test runs) stays roughly where it was with the depth-2 matrix (~14 per shard).

The fast PR lane in ci.yml keeps its compile-only depth-2 check; comments in both workflows were updated to describe the new split.