### PR TITLE
style: enable clippy::redundant_clone lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ dead_code = "allow"
 [lints.clippy]
 # Gate all clippy lints. The allowed lints are a temporary allow list that should be removed
 # over time.
-all = { level = "deny", priority = -1 }
+all = "deny"
+redundant_clone = "deny"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ unsafe_code = "forbid"
 dead_code = "allow"
 
 [lints.clippy]
-# Gate all clippy lints. The allowed lints are a temporary allow list that should be removed
-# over time.
 all = "deny"
 redundant_clone = "deny"
 

--- a/src/api/output.rs
+++ b/src/api/output.rs
@@ -122,7 +122,7 @@ fn handle_key_value_comparison(
     if let Some(key) = &comparison.key {
         let expected = match quote_if_whitespace(&key.expected) {
             (actual, true) => format!("{} ({})", actual, QUOTED_TEXT),
-            (actual, false) => actual.to_string(),
+            (actual, false) => actual,
         };
         writeln!(tw, "\tkey\t[{}]\t{}", key.operator, expected).unwrap();
     }
@@ -130,7 +130,7 @@ fn handle_key_value_comparison(
     if let Some(value) = &comparison.value {
         let expected = match quote_if_whitespace(&value.expected) {
             (expected, true) => format!("{} ({})", expected, QUOTED_TEXT),
-            (expected, false) => expected.to_string(),
+            (expected, false) => expected,
         };
         writeln!(tw, "\tvalue\t[{}]\t{}", value.operator, expected).unwrap();
     }

--- a/src/common/data.rs
+++ b/src/common/data.rs
@@ -1586,7 +1586,7 @@ impl TryFrom<&MockDefinition> for StaticMockDefinition {
 
         let mut method = None;
         if let Some(method_str) = value.request.method {
-            method = Some(Method::from_str(&method_str).map_err(|err| StaticMockConversion(err.to_string()))?);
+            method = Some(Method::from_str(&method_str).map_err(StaticMockConversion)?);
         }
 
         Ok(StaticMockDefinition {

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -153,10 +153,9 @@ impl HttpsConfigBuilder {
                 Arc::new(GeneratingCertificateResolverFactory::new(ca_cert, ca_key)?)
             }
             // If certificate data is directly provided, use it to create the resolver.
-            (_, _, _, Some(ca_cert), Some(ca_key)) => Arc::new(GeneratingCertificateResolverFactory::new(
-                ca_cert.clone(),
-                ca_key.clone(),
-            )?),
+            (_, _, _, Some(ca_cert), Some(ca_key)) => {
+                Arc::new(GeneratingCertificateResolverFactory::new(ca_cert, ca_key)?)
+            }
             // If no CA certificate information was configured, use the default.
             _ => Arc::new(GeneratingCertificateResolverFactory::new(
                 DEFAULT_CA_CERTIFICATE,

--- a/src/server/matchers/comparators.rs
+++ b/src/server/matchers/comparators.rs
@@ -469,9 +469,9 @@ impl ValueComparator<HttpMockBytes, HttpMockBytes> for BytesExactMatchComparator
     }
 
     fn distance(&self, mock_value: &Option<&HttpMockBytes>, req_value: &Option<&HttpMockBytes>) -> usize {
-        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes().clone()).unwrap_or_default();
+        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes()).unwrap_or_default();
 
-        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes().clone()).unwrap_or_default();
+        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes()).unwrap_or_default();
 
         distance_for(mock_slice.as_ref(), req_slice.as_ref())
     }
@@ -500,9 +500,9 @@ impl ValueComparator<HttpMockBytes, HttpMockBytes> for BytesIncludesComparator {
     }
 
     fn distance(&self, mock_value: &Option<&HttpMockBytes>, req_value: &Option<&HttpMockBytes>) -> usize {
-        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes().clone()).unwrap_or_default();
+        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes()).unwrap_or_default();
 
-        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes().clone()).unwrap_or_default();
+        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes()).unwrap_or_default();
 
         distance_for(mock_slice.as_ref(), req_slice.as_ref())
     }
@@ -535,9 +535,9 @@ impl ValueComparator<HttpMockBytes, HttpMockBytes> for BytesPrefixComparator {
     }
 
     fn distance(&self, mock_value: &Option<&HttpMockBytes>, req_value: &Option<&HttpMockBytes>) -> usize {
-        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes().clone()).unwrap_or_default();
+        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes()).unwrap_or_default();
 
-        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes().clone()).unwrap_or_default();
+        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes()).unwrap_or_default();
 
         // If mock has no requirement, distance is always 0
         if mock_value.is_none() || mock_slice.is_empty() {
@@ -587,9 +587,9 @@ impl ValueComparator<HttpMockBytes, HttpMockBytes> for BytesSuffixComparator {
     }
 
     fn distance(&self, mock_value: &Option<&HttpMockBytes>, req_value: &Option<&HttpMockBytes>) -> usize {
-        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes().clone()).unwrap_or_default();
+        let mock_slice = mock_value.as_ref().map(|mv| mv.to_bytes()).unwrap_or_default();
 
-        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes().clone()).unwrap_or_default();
+        let req_slice = req_value.as_ref().map(|rv| rv.to_bytes()).unwrap_or_default();
 
         // If mock has no requirement, distance is always 0
         if mock_value.is_none() || mock_slice.is_empty() {

--- a/src/server/matchers/readers.rs
+++ b/src/server/matchers/readers.rs
@@ -556,7 +556,7 @@ pub mod request_value {
 
     #[inline]
     pub fn host(req: &HttpMockRequest) -> Option<String> {
-        req.host().map(|h| h.to_string())
+        req.host()
     }
 
     #[inline]


### PR DESCRIPTION
addresses and enforces the 'redundant_clone' clippy lint.