### PR TITLE
ci: check for rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 # Fast lane: runs on every pull request and every push to master.
 #
 # CI is split into three lanes:
-#   - ci.yml (this file): lint, pairwise feature compile checks, MSRV, tests
-#     for representative feature sets, coverage, dependency policy. Fast
-#     enough to block PRs.
+#   - ci.yml (this file): lint, documentation, pairwise feature compile checks,
+#     MSRV, tests for representative feature sets, coverage, dependency policy.
+#     Fast enough to block PRs.
 #   - feature-matrix.yml: full test suite across the feature power set plus
 #     Docker integration. Master pushes, nightly, and on demand.
 #   - platform.yml: macOS/Windows and beta/nightly toolchains. Weekly.
@@ -45,6 +45,18 @@ jobs:
           components: clippy
           rustflags: ""  # clears default "-D warnings" to ensure consistency between local dev and CI
       - run: cargo clippy --all-targets --all-features
+
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo doc --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
 
   feature-combinations:
     name: Check feature combinations

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -74,7 +74,7 @@ impl MockServer {
     /// Asynchronously connects to a remote mock server running in standalone mode.
     ///
     /// # Arguments
-    /// * `address` - A string slice representing the address in the format "<host>:<port>", e.g., "127.0.0.1:8080".
+    /// * `address` - A string slice representing the address in the format `<host>:<port>`, e.g., "127.0.0.1:8080".
     ///
     /// # Returns
     /// An instance of `Self` representing the connected mock server.
@@ -102,7 +102,7 @@ impl MockServer {
     /// Synchronously connects to a remote mock server running in standalone mode.
     ///
     /// # Arguments
-    /// * `address` - A string slice representing the address in the format "<host>:<port>", e.g., "127.0.0.1:8080".
+    /// * `address` - A string slice representing the address in the format `<host>:<port>`, e.g., "127.0.0.1:8080".
     ///
     /// # Returns
     /// An instance of `Self` representing the connected mock server.
@@ -179,7 +179,6 @@ impl MockServer {
     ///
     /// # Returns
     /// An instance of `Self` representing the started mock server.
-    /// ```
     pub async fn start_async() -> Self {
         let adapter = LOCAL_SERVER_POOL_REF
             .take_or_create(LOCAL_SERVER_ADAPTER_GENERATOR)


### PR DESCRIPTION
## Summary

- add a blocking CI job that builds all-feature documentation with rustdoc warnings denied
- fix the existing invalid HTML tag and empty code block warnings

## Testing

- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`